### PR TITLE
Player graveyard, ressurect and small selector fix.

### DIFF
--- a/fireplace/cards/blackrock/collectible.py
+++ b/fireplace/cards/blackrock/collectible.py
@@ -76,3 +76,11 @@ class BRM_003:
 # Demonwrath
 class BRM_005:
 	action = [Hit(ALL_MINIONS - DEMON, 2)]
+
+
+# Resurrect
+class BRM_017:
+	def action(self):
+		minions = self.game.minionsKilled.filter(controller=self.controller)
+		if minions:
+			return [Summon(CONTROLLER, random.choice(minions).id)]

--- a/fireplace/cards/blackrock/collectible.py
+++ b/fireplace/cards/blackrock/collectible.py
@@ -26,7 +26,7 @@ class BRM_008:
 # Volcanic Lumberer
 class BRM_009:
 	def cost(self, value):
-		return value - self.game.minionsKilledThisTurn
+		return value - len(self.game.minionsKilledThisTurn)
 
 
 # Axe Flinger
@@ -46,7 +46,7 @@ class BRM_022:
 # Volcanic Drake
 class BRM_025:
 	def cost(self, value):
-		return value - self.game.minionsKilledThisTurn
+		return value - len(self.game.minionsKilledThisTurn)
 
 
 # Hungry Dragon
@@ -62,7 +62,7 @@ class BRM_001:
 	action = [Draw(CONTROLLER) * 2]
 
 	def cost(self, value):
-		return value - self.game.minionsKilledThisTurn
+		return value - len(self.game.minionsKilledThisTurn)
 
 
 # Dragon's Breath
@@ -70,7 +70,7 @@ class BRM_003:
 	action = [Hit(TARGET, 4)]
 
 	def cost(self, value):
-		return value - self.game.minionsKilledThisTurn
+		return value - len(self.game.minionsKilledThisTurn)
 
 
 # Demonwrath

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -30,6 +30,7 @@ class Game(Entity):
 		self.turn = 0
 		self.currentPlayer = None
 		self.auras = []
+		self.minionsKilled = CardList()
 		self._actionQueue = []
 
 	def __repr__(self):
@@ -131,6 +132,7 @@ class Game(Entity):
 				actions.append(Death(card))
 				card.ignoreEvents = True
 				if card.type == CardType.MINION:
+					self.minionsKilled.append(card)
 					self.minionsKilledThisTurn += 1
 					card.controller.minionsKilledThisTurn += 1
 				elif card.type == CardType.HERO:

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -31,6 +31,7 @@ class Game(Entity):
 		self.currentPlayer = None
 		self.auras = []
 		self.minionsKilled = CardList()
+		self.minionsKilledThisTurn = CardList()
 		self._actionQueue = []
 
 	def __repr__(self):
@@ -133,7 +134,7 @@ class Game(Entity):
 				card.ignoreEvents = True
 				if card.type == CardType.MINION:
 					self.minionsKilled.append(card)
-					self.minionsKilledThisTurn += 1
+					self.minionsKilledThisTurn.append(card)
 					card.controller.minionsKilledThisTurn += 1
 				elif card.type == CardType.HERO:
 					card.controller.playstate = PlayState.LOSING
@@ -237,7 +238,7 @@ class Game(Entity):
 		logging.info("%s begins turn %i", player, self.turn)
 		self.step, self.nextStep = self.nextStep, Step.MAIN_ACTION
 		self.currentPlayer = player
-		self.minionsKilledThisTurn = 0
+		self.minionsKilledThisTurn = CardList()
 
 		for p in self.players:
 			p.cardsDrawnThisTurn = 0

--- a/fireplace/targeting.py
+++ b/fireplace/targeting.py
@@ -152,6 +152,8 @@ class Selector:
 		return result
 
 	def eval(self, entities, source):
+		if not entities:
+			return []
 		self.opc = 0 # outer program counter
 		result = []
 		while self.opc < len(self.program):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3862,6 +3862,49 @@ def test_discard_enchanted_cards():
 	assert not game.player1.hand
 
 
+def test_resurrect():
+	# Doesn't summon if nothing died
+	game = prepare_game()
+	for i in range(2):
+		game.endTurn(); game.endTurn()
+	game.player1.give("BRM_017").play()
+	assert len(game.player1.field) == 0
+
+	# Summons something
+	game = prepare_game()
+	for i in range(2):
+		game.endTurn(); game.endTurn()
+	wisp = game.player1.give(WISP)
+	wisp.play()
+	game.player1.give(MOONFIRE).play(target=wisp)
+	assert len(game.player1.field) == 0
+	game.player1.give("BRM_017").play()
+	assert len(game.player1.field) == 1
+	assert game.player1.field[0] == wisp
+
+
+def test_resurrect_wild_pyro():
+	# Wild pyromancer + resurrect triggers
+	game = prepare_game()
+	for i in range(4):
+		game.endTurn(); game.endTurn()
+
+	resurrect = game.player1.give("BRM_017")
+	pyromancer = game.player1.give("NEW1_020")
+	pyromancer.play()
+	game.player1.give(MOONFIRE).play(target=pyromancer)
+	game.player1.give(MOONFIRE).play(target=pyromancer)
+	assert pyromancer.dead
+
+	game.player1.give(WISP).play()
+	assert len(game.player1.field) == 1
+
+	resurrect.play()
+	assert len(game.player1.field) == 1
+	assert game.player1.field[0].id == pyromancer.id
+	assert game.player1.field[0].health == 1
+
+
 def main():
 	for name, f in globals().items():
 		if name.startswith("test_") and hasattr(f, "__call__"):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -19,6 +19,16 @@ def test_selector():
 	assert targets[0] == alex
 
 
+def test_empty_selector():
+	game = prepare_game()
+	game.player1.discardHand()
+	game.player2.discardHand()
+	selector = Selector(Zone.HAND)
+	
+	targets = selector.eval(game.player1.hand, game.player1)
+	assert not targets
+
+
 def main():
 	for name, f in globals().items():
 		if name.startswith("test_") and hasattr(f, "__call__"):


### PR DESCRIPTION
I think on current master there is no option for checking which cards went to graveyard, so I added another cache.
Also dead property in PlayableClass actually returns true also for discarded cards, which messes up simple implementation of Resurrect/Kel Thuzad. I've solved that by tracking all zones that card went through, to see if it was ever on field. It could be also somehow solved with tags, but there are no original Hearthstone tags that differentiate dicarded card from killed minion (at least that's what Hearthstone logs show). 
I've implemented Resurrect as simple proof of everything working.

About the Selector bug, there is a problem with calling eval with empty entities (self.pc attribute won't exist at this point).
```
from test_main import prepare_game
from fireplace import targeting
game = prepare_game()
targeting.MINION.eval([], game)
```
should fail, but:
```
from test_main import prepare_game
from fireplace import targeting
game = prepare_game()
targeting.MINION.eval(game.entities, game)
targeting.MINION.eval([], game)
```
now everything is ok.