### PR TITLE
Add test for Quick Shot/Trade Prince Gallywix interaction

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4253,6 +4253,21 @@ def test_quick_shot_acolyte():
 	assert acolyte.dead
 
 
+def test_quick_shot_gallywix():
+	game = prepare_game()
+	gallywix = game.player1.give("GVG_028")
+	gallywix.play()
+	game.end_turn();
+
+	game.player2.discard_hand()
+	assert len(game.player2.hand) == 0
+	quickshot = game.player2.give("BRM_013")
+	assert len(game.player2.hand) == 1
+	quickshot.play(target=game.current_player.opponent.hero)
+	assert len(game.player2.hand) == 1
+	assert game.player2.hand[0].id == "GVG_028t"
+
+
 def test_avenge():
 	game = prepare_game()
 	avenge = game.player1.give("FP1_020")


### PR DESCRIPTION
Related to #66: Add test for the Quick Shot + Trade Prince Gallywix interaction.

Correct behaviour when playing Quick Shot from an empty hand with enemy Gallywix on board:
Gallywix triggers first giving the player a Gallywix coin, blocking Quick Shot from drawing a card ([documented here](https://www.reddit.com/r/hearthstone/comments/37trcu/psa_interaction_between_quick_shot_and_gallywix/)).