### PR TITLE
Fix secret/death interactions

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -587,7 +587,7 @@ class Reveal(TargetedAction):
 	def do(self, source, target):
 		logging.info("Revealing secret %r", target)
 		self.broadcast(source, EventListener.ON, target)
-		target.destroy()
+		target.zone = Zone.GRAVEYARD
 
 
 class SetCurrentHealth(TargetedAction):

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -347,7 +347,6 @@ class Character(PlayableCard):
 		self.cant_be_targeted_by_hero_powers = False
 		self.num_attacks = 0
 		self.race = Race.INVALID
-		self.should_exit_combat = False
 		super().__init__(*args)
 
 	@property
@@ -397,20 +396,16 @@ class Character(PlayableCard):
 			return True
 		return False
 
-	def _set_zone(self, zone):
-		if self.attacking:
-			self.should_exit_combat = True
-		super()._set_zone(zone)
+	@property
+	def should_exit_combat(self):
+		if self.dead or self.zone != Zone.PLAY:
+			return True
+		return False
 
 	def attack(self, target):
 		assert target.zone == Zone.PLAY
 		assert self.controller.current_player
 		self.game.attack(self, target)
-
-	def _destroy(self):
-		if self.attacking:
-			self.should_exit_combat = True
-		super()._destroy()
 
 	@property
 	def damaged(self):

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -1,7 +1,7 @@
 import logging
 from itertools import chain
 from . import cards as CardDB, rules
-from .actions import Damage, Deaths, Destroy, Heal, Morph, Play, Shuffle
+from .actions import Damage, Deaths, Destroy, Heal, Morph, Play, Shuffle, SetCurrentHealth
 from .entity import Entity, boolean_property, int_property
 from .enums import AuraType, CardType, PlayReq, Race, Zone
 from .managers import *
@@ -445,6 +445,9 @@ class Character(PlayableCard):
 		if self.zone == Zone.PLAY:
 			return self.attack_targets
 		return super().targets
+
+	def set_current_health(self, amount):
+		return self.game.queue_actions(self, [SetCurrentHealth(self, amount)])
 
 
 class Hero(Character):

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -93,7 +93,6 @@ class BaseGame(Entity):
 		self.proposed_defender = None
 		if attacker.should_exit_combat:
 			logging.info("Attack has been interrupted.")
-			attacker.should_exit_combat = False
 			attacker.attacking = False
 			defender.defending = False
 			return

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3844,6 +3844,21 @@ def test_truesilver_champion():
 	assert lightwarden.atk == 3
 
 
+def test_truesilver_champion_explosive_trap():
+	game = prepare_game()
+	explosivetrap = game.player1.give("EX1_610")
+	explosivetrap.play()
+	game.end_turn()
+	game.player2.hero.set_current_health(2)
+	assert game.player2.hero.health == 2
+	truesilver = game.player2.give("CS2_097")
+	truesilver.play()
+	game.player2.hero.attack(game.player1.hero)
+	assert explosivetrap.dead
+	assert game.player2.hero.health == 2
+	assert game.player1.hero.health == 26
+
+
 def test_tinkertown_technician():
 	game = prepare_game()
 	game.player1.discard_hand()


### PR DESCRIPTION
This PR:
- adds a test for the Truesilver Champion/Explosive Trap interaction
- adds `set_current_health()` in Character
- reworks secret reveals (moving them directly to the graveyard without destruction)
- simplifies `should_exit_combat` to a read-only property
- fixes #5