### PR TITLE
Fix FullHeal()

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -431,7 +431,7 @@ class FullHeal(TargetedAction):
 	Fully heal character targets.
 	"""
 	def do(self, source, target):
-		source.heal(target, target.health)
+		source.heal(target, target.max_health)
 
 
 class GainArmor(TargetedAction):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1036,14 +1036,16 @@ def test_ancestors_call():
 
 
 def test_ancestral_healing():
-	game = prepare_game()
-	ancestral = game.current_player.give("CS2_041")
-	wisp = game.current_player.give(WISP)
-	wisp.play()
-	assert not wisp.taunt
-	ancestral.play(wisp)
-	assert wisp.health == 1
-	assert wisp.taunt
+	game = prepare_empty_game()
+	watcher = game.current_player.give("EX1_045")
+	watcher.play()
+	assert not watcher.taunt
+	assert watcher.health == 5
+	watcher.set_current_health(1)
+	assert watcher.health == 1
+	game.current_player.give("CS2_041").play(watcher)
+	assert watcher.taunt
+	assert watcher.health == 5
 
 
 def test_ancestral_spirit():


### PR DESCRIPTION
Currently `FullHeal()` only heals the target by it's current health, effectively doubling it's health (limited by max_health).

This PR:
- fixes `FullHeal()` to always heal the missing amount of points
- updates the Ancestral Healing test to actually test the heal