### PR TITLE
Rework ForceDraw(), fixing Captain's Parrot and Sense Demons

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -395,7 +395,7 @@ class Discard(TargetedAction):
 
 class Draw(TargetedAction):
 	"""
-	Make player targets draw \a count cards.
+	Make player targets draw a card from their deck.
 	"""
 	class Args(Action.Args):
 		TARGETS = 0
@@ -414,16 +414,10 @@ class Draw(TargetedAction):
 
 class ForceDraw(TargetedAction):
 	"""
-	Make player targets draw \a cards from their deck.
+	Draw card targets into their owners hand
 	"""
-	class Args(Action.Args):
-		TARGETS = 0
-		CARDS = 1
-
 	def do(self, source, target):
-		cards = self.eval(self.cards, source)
-		for card in cards:
-			card.draw()
+		target.draw()
 
 
 class FullHeal(TargetedAction):

--- a/fireplace/cards/classic/neutral_epic.py
+++ b/fireplace/cards/classic/neutral_epic.py
@@ -41,7 +41,7 @@ class EX1_620:
 
 # Captain's Parrot
 class NEW1_016:
-	play = ForceDraw(CONTROLLER, CONTROLLER_DECK + PIRATE)
+	play = ForceDraw(RANDOM(CONTROLLER_DECK + PIRATE))
 
 
 # Hungry Crab

--- a/fireplace/cards/classic/warlock.py
+++ b/fireplace/cards/classic/warlock.py
@@ -144,8 +144,8 @@ class EX1_316e:
 # Sense Demons
 class EX1_317:
 	play = (
-		Find(CONTROLLER_DECK + MINION + DEMON) &
-		Draw(CONTROLLER, RANDOM(CONTROLLER_DECK + MINION + DEMON)) |
+		Find(CONTROLLER_DECK + DEMON) &
+		ForceDraw(RANDOM(CONTROLLER_DECK + DEMON)) |
 		Give(CONTROLLER, "EX1_317t"),
 	) * 2
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4203,6 +4203,34 @@ def test_savage_roar():
 	assert game.player2.hero.atk == 0
 
 
+def test_sense_demons():
+	game = prepare_empty_game()
+	game.player1.discard_hand()
+	demon1 = game.player1.give("EX1_319")
+	demon1.shuffle_into_deck()
+	demon2 = game.player1.give("CS2_065")
+	demon2.shuffle_into_deck()
+	wisp = game.player1.give(WISP)
+	wisp.shuffle_into_deck()
+	assert len(game.player1.deck) == 3
+	assert len(game.player1.hand) == 0
+	sense1 = game.player1.give("EX1_317")
+	sense1.play()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 2
+	assert game.player1.hand.contains(demon1)
+	assert game.player1.hand.contains(demon2)
+
+	game.player1.discard_hand()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 0
+	sense2 = game.player1.give("EX1_317")
+	sense2.play()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 2
+	assert game.player1.hand[0].id == game.player1.hand[1].id == "EX1_317t"
+
+
 def test_shadowflame():
 	game = prepare_game()
 	dummy1 = game.player1.give(TARGET_DUMMY)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1482,6 +1482,32 @@ def test_healing_totem():
 	assert footman.health == 2
 
 
+def test_captains_parrot():
+	game = prepare_empty_game()
+	pirate1 = game.player1.give("NEW1_022")
+	pirate1.shuffle_into_deck()
+	pirate2 = game.player1.give("CS2_146")
+	pirate2.shuffle_into_deck()
+	wisp = game.player1.give(WISP)
+	wisp.shuffle_into_deck()
+	assert len(game.player1.deck) == 3
+	game.player1.give("NEW1_016").play()
+	assert len(game.player1.deck) == 2
+	assert len(game.player1.hand) == 1
+	assert game.player1.hand[0].race == Race.PIRATE
+	game.player1.discard_hand()
+	game.player1.give("NEW1_016").play()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 1
+	assert game.player1.hand[0].race == Race.PIRATE
+	game.player1.discard_hand()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 0
+	game.player1.give("NEW1_016").play()
+	assert len(game.player1.deck) == 1
+	assert len(game.player1.hand) == 0
+
+
 def test_crazed_alchemist():
 	game = prepare_game()
 	alchemist = game.current_player.give("EX1_059")


### PR DESCRIPTION
This PR:
- reworks ForceDraw() to accept a single card target or list of card targets which are then drawn
- fixes Captain's Parrot and adds a test (fixing #100)
- fixes Sense Demons and adds a test

Considerations:
- removing the player target made sense, because you cannot simply draw a card from your deck into the other players hand
- ~~should ForceDraw do the RANDOM by itself, if it gets a list? Then we could have a simpler `ForceDraw(MINION + PIRATE)` instead of `ForceDraw(RANDOM(MINION + PIRATE))`. On the other hand, the current implementation also allows multiple cards to be drawn at once (without an outer quantifier like `*2`) or very specific cards to be drawn~~ stay with how it currently is for flexibility
- ~~we should broadast a `Draw` event~~ (no need to broadcast - Chromaggus, Flame Leviathan, ... do not get triggered)