### PR TITLE
Implement GainEmptyMana and add mana crystal tests

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -477,6 +477,19 @@ class GainMana(TargetedAction):
 		target.max_mana += amount
 
 
+class GainEmptyMana(TargetedAction):
+	"""
+	Give player targets \a amount empty Mana crystals.
+	"""
+	class Args(Action.Args):
+		TARGETS = 0
+		AMOUNT = 1
+
+	def do(self, source, target, amount):
+		target.max_mana += amount
+		target.used_mana += amount
+
+
 class Give(TargetedAction):
 	"""
 	Give player targets card \a id.

--- a/fireplace/cards/classic/druid.py
+++ b/fireplace/cards/classic/druid.py
@@ -94,7 +94,7 @@ class CS2_012:
 class CS2_013:
 	def play(self):
 		if self.controller.max_mana < self.controller.max_resources:
-			return GainMana(CONTROLLER, 1)
+			return GainEmptyMana(CONTROLLER, 1)
 		else:
 			return Give(CONTROLLER, "CS2_013t")
 

--- a/fireplace/cards/classic/warlock.py
+++ b/fireplace/cards/classic/warlock.py
@@ -24,7 +24,7 @@ class CS2_064:
 
 # Felguard
 class EX1_301:
-	play = GainMana(CONTROLLER, -1)
+	play = GainEmptyMana(CONTROLLER, -1)
 
 
 # Void Terror

--- a/fireplace/cards/gvg/druid.py
+++ b/fireplace/cards/gvg/druid.py
@@ -15,7 +15,7 @@ class GVG_030b:
 
 # Gift of Mana (Grove Tender)
 class GVG_032a:
-	play = GainMana(ALL_PLAYERS, 1), FillMana(ALL_PLAYERS, 1)
+	play = GainMana(ALL_PLAYERS, 1)
 
 # Gift of Cards (Grove Tender)
 class GVG_032b:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1493,6 +1493,20 @@ def test_arcane_explosion():
 	assert len(game.current_player.opponent.field) == 0
 
 
+def test_arcane_golem():
+	game = prepare_game(game_class=Game)
+	golem = game.player1.give("EX1_089")
+	for i in range(3):
+		game.end_turn(); game.end_turn()
+
+	assert game.player1.max_mana == 4
+	assert game.player2.max_mana == 3
+	golem.play()
+	assert golem.charge
+	assert game.player1.max_mana == 4
+	assert game.player2.max_mana == 4
+
+
 def test_arcane_missiles():
 	game = prepare_game()
 	missiles = game.current_player.give("EX1_277")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4843,6 +4843,17 @@ def test_fel_cannon():
 	assert wisp.dead
 
 
+def test_felguard():
+	game = prepare_game(game_class=Game)
+	for i in range(3):
+		game.end_turn(); game.end_turn()
+	assert game.player1.max_mana == 4
+	felguard = game.player1.give("EX1_301")
+	felguard.play()
+	assert game.player1.max_mana == 3
+	assert game.player1.mana == 1
+
+
 def test_fireguard_destroyer():
 	game = prepare_game()
 	fireguard = game.player1.give("BRM_012")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4103,6 +4103,31 @@ def test_wild_pyromancer():
 	assert pyro.zone == Zone.PLAY
 
 
+def test_wild_growth():
+	game = prepare_game(game_class=Game)
+	game.end_turn(); game.end_turn()
+	assert game.player1.max_mana == 2
+	wildgrowth1 = game.player1.give("CS2_013")
+	wildgrowth1.play()
+	assert game.player1.mana == 0
+	assert game.player1.used_mana == 2 + 1
+	assert game.player1.max_mana == 2 + 1
+	for i in range(8):
+		game.end_turn(); game.end_turn()
+
+	game.player1.discard_hand()
+	assert len(game.player1.hand) == 0
+	assert game.player1.max_mana == 10
+	wildgrowth2 = game.player1.give("CS2_013")
+	wildgrowth2.play()
+	assert len(game.player1.hand) == 1
+	assert game.player1.max_mana == 10
+	excess_mana = game.player1.hand[0]
+	assert excess_mana.id == "CS2_013t"
+	excess_mana.play()
+	assert len(game.player1.hand) == 1
+
+
 def test_wrathguard():
 	game = prepare_game()
 	wrathguard = game.player1.give("AT_026")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2958,6 +2958,29 @@ def test_grimscale_oracle():
 	assert murloc2.atk == 2
 
 
+def test_grove_tender():
+	game = prepare_game(game_class=Game)
+	for i in range(3):
+		game.end_turn(); game.end_turn()
+
+	assert game.player1.max_mana == 4
+	assert game.player2.max_mana == 3
+	grovetender1 = game.player1.give("GVG_032")
+	grovetender1.play(choose="GVG_032a")
+	assert game.player1.max_mana == 5
+	assert game.player2.max_mana == 4
+	assert game.player1.mana == 2
+	assert game.player1.used_mana == 3
+	game.end_turn(); game.end_turn()
+
+	game.player1.discard_hand()
+	game.player2.discard_hand()
+	grovetender2 = game.player1.give("GVG_032")
+	grovetender2.play(choose="GVG_032b")
+	assert len(game.player1.hand) == 1
+	assert len(game.player2.hand) == 1
+
+
 def test_gruul():
 	game = prepare_game()
 	gruul = game.current_player.give("NEW1_038")


### PR DESCRIPTION
This PR:
- adds GainEmptyMana as alternative to `GainMana`
- fixes Wild Growth to use `GainEmptyMana` instead of  `GainMana`
- adds a test for Wild Growth
- fixes Grove Tender to correctly use `GainMana`
- adds a test for Grove Tender
- fixes Felguard to not destroy full mana crystals when played
- adds a test for Felguard
- adds a test for Arcane Golem