### PR TITLE
Implement Redemption

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -649,6 +649,8 @@ class Summon(TargetedAction):
 			card.zone = Zone.PLAY
 			self.broadcast(source, EventListener.AFTER, target, card)
 
+		return cards
+
 
 class Shuffle(TargetedAction):
 	"""

--- a/fireplace/cards/classic/paladin.py
+++ b/fireplace/cards/classic/paladin.py
@@ -133,6 +133,13 @@ class EX1_132:
 	)
 
 
+# Redemption
+class EX1_136:
+	events = Death(FRIENDLY + MINION).on(
+		SetCurrentHealth(Summon(CONTROLLER, Copy(Death.Args.ENTITY)), 1), Reveal(SELF)
+	)
+
+
 # Repentance
 class EX1_379:
 	events = Play(OPPONENT, MINION).after(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3463,6 +3463,26 @@ def test_recombobulator():
 	assert game.player1.field[0].cost == 0
 
 
+def test_redemption():
+	game = prepare_game()
+	redemption = game.player1.give("EX1_136")
+	redemption.play()
+	footman = game.player1.give(GOLDSHIRE_FOOTMAN)
+	footman.play()
+	game.end_turn()
+	
+	assert footman.health == 2
+	assert len(game.player1.field) == 1
+	assert len(game.player2.field) == 0
+	footman.destroy()
+	assert redemption not in game.player1.secrets
+	assert len(game.player1.field) == 1
+	assert len(game.player2.field) == 0
+	target = game.player1.field[0]
+	assert target.id == GOLDSHIRE_FOOTMAN
+	assert target.health == 1
+
+
 def test_reincarnate():
 	game = prepare_game()
 


### PR DESCRIPTION
This PR:
- makes `Summon` return the summoned cards
- implements Redemption
- adds a test for Redemption

Note that this PR does not check or fix secrets triggering on the own turn, see issue #123.