### PR TITLE
Add Inspire action and implement Void Crusher

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -541,6 +541,18 @@ class Heal(TargetedAction):
 			self.broadcast(source, EventListener.ON, target, amount)
 
 
+class Inspire(TargetedAction):
+	"""
+	Trigger inspire on card targets.
+	"""
+	def do(self, source, target):
+		if hasattr(target.data.scripts, "inspire"):
+			actions = target.data.scripts.inspire
+			if actions:
+				self.broadcast(source, EventListener.ON, target)
+				source.game.queue_actions(target, actions)
+
+
 class ManaThisTurn(TargetedAction):
 	"""
 	Give player targets \a amount Mana this turn.

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -1,11 +1,12 @@
 from itertools import chain
 from . import cards as CardDB, rules
-from .actions import Damage, Deaths, Destroy, Heal, Morph, Play, Shuffle, SetCurrentHealth
+from .actions import Damage, Deaths, Destroy, Heal, Inspire, Morph, Play, Shuffle, SetCurrentHealth
 from .aura import TargetableByAuras
 from .entity import Entity, boolean_property, int_property
 from .enums import CardType, PlayReq, Race, Rarity, Zone
 from .managers import CardManager
 from .targeting import is_valid_target
+from .dsl import FRIENDLY_MINIONS
 from .utils import CardList
 from .exceptions import InvalidAction
 
@@ -783,12 +784,7 @@ class HeroPower(PlayableCard):
 		if actions:
 			ret += self.game.queue_actions(self, actions)
 
-		for minion in self.controller.field.filter(has_inspire=True):
-			if not hasattr(minion.data.scripts, "inspire"):
-				raise NotImplementedError("Missing inspire script for %r" % (minion))
-			actions = minion.data.scripts.inspire
-			if actions:
-				ret += self.game.queue_actions(self, actions)
+		ret += self.game.queue_actions(self, [Inspire(FRIENDLY_MINIONS)])
 
 		return ret
 

--- a/fireplace/cards/tgt/warlock.py
+++ b/fireplace/cards/tgt/warlock.py
@@ -14,6 +14,11 @@ class AT_021:
 	events = Discard(FRIENDLY).on(Buff(SELF, "AT_021e"))
 
 
+# Void Crusher
+class AT_023:
+	inspire = Destroy(RANDOM_ENEMY_MINION | RANDOM_FRIENDLY_MINION)
+
+
 # Wrathguard
 class AT_026:
 	events = Damage(SELF).on(Hit(FRIENDLY_HERO, Damage.Args.AMOUNT))


### PR DESCRIPTION
This PR:
- adds an `Inspire` action,
- changes hero powers to call  `Inspire` to trigger inspire scripts,
- implements Void Crusher