### PR TITLE
fix 2 bugs preventing shadow madnessed minions from attacking + test

### DIFF
--- a/fireplace/cards/classic/priest.py
+++ b/fireplace/cards/classic/priest.py
@@ -124,6 +124,10 @@ class EX1_334e:
 		TURN_END.on(Destroy(SELF))
 	]
 
+	def apply(self, target):
+		target.charge = True
+		target.num_attacks = 0
+
 	def destroy(self):
 		self.controller.opponent.steal(self.owner)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5436,6 +5436,50 @@ def test_powermace():
 	assert dummy.atk == 0 + 2
 	assert dummy.health == 2 + 2
 
+# test that shadow madnessing a minion that attacked on the opponent's previous
+# turn allows it to attack
+def test_shadow_madness_attack():
+	game = prepare_game()
+
+	wisp = game.player1.give(WISP).play()
+	game.end_turn(); game.end_turn();
+	assert wisp.controller is game.player1
+	assert wisp.can_attack()
+	wisp.attack(game.player2.hero)
+	game.end_turn()
+
+	shadowmadness = game.player2.give("EX1_334")
+	shadowmadness.play(target=wisp)
+	assert wisp.controller is game.player2
+	assert wisp.can_attack()
+	wisp.attack(game.player1.hero)
+	game.end_turn();
+
+	# make sure it can attack when control returns
+	assert wisp.controller is game.player1
+	assert wisp.can_attack()
+	wisp.attack(game.player2.hero)
+
+# test that shadow madnessing a minion that was just played by the opponent
+# allows it to attack
+def test_shadow_madness_attack_2():
+	game = prepare_game()
+
+	wisp = game.player1.give(WISP).play()
+	game.end_turn()
+	assert wisp.controller is game.player1
+
+	shadowmadness = game.player2.give("EX1_334")
+	shadowmadness.play(target=wisp)
+	assert wisp.controller is game.player2
+	assert wisp.can_attack()
+	wisp.attack(game.player1.hero)
+	game.end_turn()
+
+	# make sure it can attack when control returns
+	assert wisp.controller is game.player1
+	assert wisp.can_attack()
+	wisp.attack(game.player2.hero)
 
 def main():
 	for name, f in globals().items():


### PR DESCRIPTION
Two separate but related bugs with Shadow Madness:
- if P1 plays a minion, P2 can't attack after SM since the minion's # turns in play is 0
- if P1 attacks with a minion, P2 can't attack after SM since the minion's # attacks hasn't reset yet