### PR TITLE
Implement Activate() action and add tests

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -268,6 +268,34 @@ class Play(GameAction):
 		card.choose = None
 
 
+class Activate(GameAction):
+	class Args(Action.Args):
+		PLAYER = 0
+		HEROPOWER = 1
+		TARGET = 2
+
+	def get_args(self, source):
+		return (source, ) + super().get_args(source)
+
+	def do(self, source, player, heropower, target=None):
+		ret = []
+
+		self.broadcast(source, EventListener.ON, heropower, target);
+
+		actions = heropower.get_actions("activate")
+		if actions:
+			ret += source.game.queue_actions(heropower, actions)
+
+		for minion in player.field.filter(has_inspire=True):
+			actions = minion.get_actions("inspire")
+			if actions is None:
+				raise NotImplementedError("Missing inspire script for %r" % (minion))
+			if actions:
+				ret += source.game.queue_actions(minion, actions)
+
+		return ret
+
+
 class TargetedAction(Action):
 	class Args(Action.Args):
 		TARGETS = 0

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -1,6 +1,6 @@
 from itertools import chain
 from . import cards as CardDB, rules
-from .actions import Damage, Deaths, Destroy, Heal, Morph, Play, Shuffle, SetCurrentHealth
+from .actions import Activate, Damage, Deaths, Destroy, Heal, Morph, Play, Shuffle, SetCurrentHealth
 from .aura import TargetableByAuras
 from .entity import Entity, boolean_property, int_property
 from .enums import CardType, PlayReq, Race, Rarity, Zone
@@ -758,20 +758,7 @@ class HeroPower(PlayableCard):
 		super()._set_zone(value)
 
 	def activate(self):
-		actions = self.get_actions("activate")
-
-		ret = []
-		if actions:
-			ret += self.game.queue_actions(self, actions)
-
-		for minion in self.controller.field.filter(has_inspire=True):
-			actions = minion.get_actions("inspire")
-			if actions is None:
-				raise NotImplementedError("Missing inspire script for %r" % (minion))
-			if actions:
-				ret += self.game.queue_actions(minion, actions)
-
-		return ret
+		return self.game.queue_actions(self.controller, [Activate(self, self.target)])
 
 	def hit(self, target, amount):
 		amount += self.controller.heropower_damage

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -59,6 +59,16 @@ def test_play_choose_without_choice():
 		powerofwild.play()
 
 
+def test_play_game_over():
+	game = prepare_game()
+	moonfire = game.player1.give(MOONFIRE)
+	game.player2.hero.set_current_health(1)
+	with pytest.raises(GameOver):
+		moonfire.play(target=game.player2.hero)
+	assert game.player1.playstate == PlayState.WON
+	assert game.player2.playstate == PlayState.LOST
+
+
 def test_attack_without_charge():
 	game = prepare_game()
 	wisp = game.player1.give(WISP)
@@ -113,6 +123,18 @@ def test_attack_own_minion():
 		game.player1.hero.attack(wisp)
 
 
+def test_attack_game_over():
+	game = prepare_game()
+	wisp = game.player1.give(WISP)
+	wisp.play()
+	game.end_turn(); game.end_turn()
+	game.player2.hero.set_current_health(1)
+	with pytest.raises(GameOver):
+		wisp.attack(target=game.player2.hero)
+	assert game.player1.playstate == PlayState.WON
+	assert game.player2.playstate == PlayState.LOST
+
+
 def test_hero_power_on_wrong_turn():
 	game = prepare_game(WARRIOR, WARRIOR)
 	game.end_turn()
@@ -132,3 +154,20 @@ def test_hero_power_without_target():
 	game = prepare_game(MAGE, MAGE)
 	with pytest.raises(InvalidAction):
 		game.player1.hero.power.use()
+
+
+def test_hero_power_game_over():
+	game = prepare_game(MAGE, MAGE)
+	game.player2.hero.set_current_health(1)
+	with pytest.raises(GameOver):
+		game.player1.hero.power.use(target=game.player2.hero)
+	assert game.player1.playstate == PlayState.WON
+	assert game.player2.playstate == PlayState.LOST
+
+
+def test_hero_destroy_game_over():
+	game = prepare_game()
+	with pytest.raises(GameOver):
+		game.player2.hero.destroy()
+	assert game.player1.playstate == PlayState.WON
+	assert game.player2.playstate == PlayState.LOST

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1659,6 +1659,20 @@ def test_voidcaller():
 	assert len(game.current_player.hand) == 3
 
 
+def test_void_crusher():
+	game = prepare_game(WARLOCK, WARLOCK)
+	for i in range(3):
+		game.player2.summon(WISP)
+	crusher = game.player1.give("AT_023")
+	crusher.play()
+	assert len(game.player1.field) == 1
+	assert len(game.player2.field) == 3
+	game.player1.hero.power.use()
+	assert crusher.dead
+	assert len(game.player1.field) == 0
+	assert len(game.player2.field) == 2
+
+
 def test_void_terror():
 	game = prepare_game()
 	terror1 = game.current_player.give("EX1_304")


### PR DESCRIPTION
This PR:
- implements the `Activate()` action (like `Play()`) (closing #161)
- finally adds the test for Void Crusher since it works now
- adds tests for hero kills using play/attack/hero power (closing #142)