### PR TITLE
Add test for Lord Jaraxxus and Molten Giant

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3831,6 +3831,15 @@ def test_nerubar_weblord():
 	assert perdition1.cost == perdition2.cost == 3
 
 
+def test_lord_jaraxxus_molten():
+	game = prepare_game()
+	jaraxxus = game.player1.give("EX1_323")
+	molten = game.player1.give("EX1_620")
+	jaraxxus.play()
+	assert game.player1.hero.health == 15
+	assert molten.cost == 20
+
+
 def test_noble_sacrifice():
 	game = prepare_game()
 	sacrifice = game.player1.give("EX1_130")


### PR DESCRIPTION
FWIW, this test confirms that the mana cost of Molten Giant is not affected by _setting_ (in contrast to _damaging_) the hero's health as in playing Lord Jaraxxus.

Of course, you can just decline this PR if you find this test to be trivial or redundant.