### PR TITLE
Fix DSL selector tests with empty entities

### DIFF
--- a/fireplace/dsl/selector.py
+++ b/fireplace/dsl/selector.py
@@ -347,10 +347,10 @@ class Affiliation(IntEnum):
 
 
 # Enum tests
-GameTag.test = lambda self, entity, *args: bool(entity.tags.get(self))
-CardType.test = lambda self, entity, *args: self == entity.type
-Race.test = lambda self, entity, *args: self == getattr(entity, "race", Race.INVALID)
-Zone.test = lambda self, entity, *args: self == entity.zone
+GameTag.test = lambda self, entity, *args: entity is not None and bool(entity.tags.get(self))
+CardType.test = lambda self, entity, *args: entity is not None and self == entity.type
+Race.test = lambda self, entity, *args: entity is not None and self == getattr(entity, "race", Race.INVALID)
+Zone.test = lambda self, entity, *args: entity is not None and self == entity.zone
 
 
 BATTLECRY = Selector(GameTag.BATTLECRY)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -960,6 +960,24 @@ def test_spellbender():
 	assert target.health == 2
 
 
+def test_spellbender_echo_of_medivh():
+	game = prepare_game()
+	game.player1.discard_hand()
+	spellbender = game.player1.give("tt_010")
+	spellbender.play()
+	game.end_turn()
+
+	game.player2.discard_hand()
+	wisp = game.player2.give(WISP)
+	echo = game.player2.give("GVG_005")
+	wisp.play()
+	echo.play()
+
+	assert spellbender in game.player1.secrets
+	assert len(game.player2.hand) == 1
+	assert game.player2.hand[0].id == WISP
+
+
 def test_spiteful_smith():
 	game = prepare_game()
 	assert not game.current_player.hero.atk


### PR DESCRIPTION
This PR:
- fixes DSL selector tests failing if no entity is passed
- adds a test from @oftc-ftw to verify the correct behaviour with Echo of Medivh (I had to slightly fix it)