### PR TITLE
Do not destroy minions in bounce() if they're already dead

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -618,7 +618,8 @@ class Minion(Character):
 		self.log("%r is bounced back to %s's hand", self, self.controller)
 		if len(self.controller.hand) >= self.controller.max_hand_size:
 			self.log("%s's hand is full and bounce fails", self.controller)
-			self.destroy()
+			if not self.dead:
+				self.destroy()
 		else:
 			self.zone = Zone.HAND
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,6 +55,45 @@ def test_cobalt_guardian():
 	assert cobalt.divine_shield
 
 
+def test_the_skeleton_knight():
+	game = prepare_empty_game()
+	skeleton_knight = game.player1.give("AT_128")
+	assert not skeleton_knight.dead
+	skeleton_knight.play()
+	assert skeleton_knight.atk == 7
+	assert skeleton_knight.health == 4
+
+	# prepare joust
+	ancient = game.player1.give("EX1_045")
+	wisp = game.player2.give(WISP)
+	ancient.shuffle_into_deck()
+	wisp.shuffle_into_deck()
+
+	skeleton_knight.destroy()
+	assert len(game.player1.field) == 0
+	assert game.player1.hand.contains("AT_128")
+
+
+def test_the_skeleton_knight_full_hand():
+	game = prepare_empty_game()
+	skeleton_knight = game.player1.give("AT_128")
+	skeleton_knight.play()
+
+	# prepare joust
+	ancient = game.player1.give("EX1_045")
+	wisp = game.player2.give(WISP)
+	ancient.shuffle_into_deck()
+	wisp.shuffle_into_deck()
+
+	for i in range(0, 10):
+		game.player1.give(WISP)
+	assert len(game.player1.hand) == 10
+
+	skeleton_knight.destroy()
+	assert len(game.player1.field) == 0
+	assert not game.player1.hand.contains("AT_128")
+
+
 def test_cogmaster():
 	game = prepare_game()
 	cogmaster = game.current_player.give("GVG_013")


### PR DESCRIPTION
This fixes The Skeleton Knight error when the hand is full and `bounce` tries to destroy the minion again.

Includes the tests from @oftc-ftw.