### PR TITLE
Fix RandomCardPicker returning heroes

### DIFF
--- a/fireplace/cards/__init__.py
+++ b/fireplace/cards/__init__.py
@@ -43,11 +43,14 @@ def filter(**kwargs):
 	"""
 	cards = db.values()
 
+	if "type" not in kwargs:
+		kwargs["type"] = [CardType.SPELL, CardType.WEAPON, CardType.MINION]
+
 	for attr, value in kwargs.items():
 		if value is not None:
 			# What? this doesn't work?
 			# cards = __builtins__["filter"](lambda c: getattr(c, attr) == value, cards)
-			cards = [card for card in cards if getattr(card, attr) == value]
+			cards = [card for card in cards if (isinstance(value, list) and getattr(card, attr) in value) or getattr(card, attr) == value]
 
 	return [card.id for card in cards]
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from utils import *
 from fireplace.dsl import *
+from fireplace.card import Card
 
 
 def test_selector():
@@ -24,3 +25,13 @@ def test_empty_selector():
 
 	targets = selector.eval(game.player1.hand, game.player1)
 	assert not targets
+
+
+def test_random_card_picker():
+	picker = RandomCardPicker()
+	ids = picker.cards
+	for id in ids:
+		card = Card(id)
+		assert card.type is not CardType.HERO
+		assert card.type is not CardType.ENCHANTMENT
+		assert card.type is not CardType.HERO_POWER

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3215,8 +3215,10 @@ def test_grand_crusader():
 	assert len(game.player1.hand) == 1
 	crusader.play()
 	assert len(game.player1.hand) == 1
-	assert game.player1.hand[0].card_class == CardClass.PALADIN
-	assert game.player1.hand[0].data.collectible
+	card = game.player1.hand[0]
+	assert card.card_class == CardClass.PALADIN
+	assert card.data.collectible
+	assert card.type != CardType.HERO
 
 
 def test_grimscale_oracle():
@@ -6024,7 +6026,9 @@ def test_burgle():
 	burgle.play()
 	assert len(game.player1.hand) == 2
 	assert game.player1.hand[0].card_class == game.player2.hero.card_class
+	assert game.player1.hand[0].type != CardType.HERO
 	assert game.player1.hand[1].card_class == game.player2.hero.card_class
+	assert game.player1.hand[1].type != CardType.HERO
 
 
 def main():


### PR DESCRIPTION
This PR:
- explicitely only allows Spells, Weapons or Minions to be randomly selected by `RandomCardPicker`, unless the type is set 
- adds a relevant test for `RandomCardPicker`
- fixes #205 and updates tests