### PR TITLE
Fixed Unfreezing with Exhausted State

### DIFF
--- a/fireplace/dsl/evaluator.py
+++ b/fireplace/dsl/evaluator.py
@@ -106,6 +106,10 @@ class Joust(Evaluator):
 	def check(self, source):
 		t1 = self.selector1.eval(source.game, source)
 		t2 = self.selector2.eval(source.game, source)
+		if not t1:
+			return False
+		elif not t2:
+			return True
 		diff = sum(t.cost for t in t1) - sum(t.cost for t in t2)
 		logger.info("Jousting %r vs %r -> %i difference", t1, t2, diff)
 		return diff > 0

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -113,8 +113,9 @@ class BaseGame(Entity):
 		cost = card.cost
 		if player.temp_mana:
 			# The coin, Innervate etc
-			cost -= player.temp_mana
-			player.temp_mana = max(0, player.temp_mana - card.cost)
+			used_temp = min(player.temp_mana, cost)
+			cost -= used_temp
+			player.temp_mana -= used_temp
 		player.used_mana += cost
 		player.last_card_played = card
 		card.play_counter = self.play_counter

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -281,7 +281,7 @@ class BaseGame(Entity):
 	def end_turn_cleanup(self):
 		self.manager.step(self.next_step, Step.MAIN_NEXT)
 		for character in self.current_player.characters.filter(frozen=True):
-			if not character.num_attacks:
+			if not character.num_attacks and not character.exhausted:
 				self.log("Freeze fades from %r", character)
 				character.frozen = False
 		for buff in self.current_player.entities.filter(one_turn_effect=True):

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -356,20 +356,33 @@ def test_graveyard_secrets():
 
 def test_joust():
 	game = prepare_empty_game()
+	
+	# Jouster loses by default if she has no minions left.
+	game.queue_actions(game.player1, [JOUST & Give(game.player1, TARGET_DUMMY)])
+	assert not game.player1.hand.filter(id=TARGET_DUMMY)
+	
 	wisp = game.player1.give(WISP)
 	wisp.shuffle_into_deck()
 	wisp2 = game.player1.give(WISP)
 	wisp2.shuffle_into_deck()
+	
+	# Jouster wins by default if opponent has no minions left.
+	game.queue_actions(game.player1, [JOUST & Give(game.player1, TARGET_DUMMY)])
+	assert game.player1.hand.filter(id=TARGET_DUMMY)
+	game.player1.hand.filter(id=TARGET_DUMMY)[0].play()
 	game.end_turn()
 
+	# Joust succeeds: 1 > 0
 	goldshire = game.player2.give(GOLDSHIRE_FOOTMAN)
 	goldshire.shuffle_into_deck()
 	game.queue_actions(game.player2, [JOUST & Give(game.player2, TARGET_DUMMY)])
 	assert game.player2.hand.filter(id=TARGET_DUMMY)
 	game.end_turn()
 
+	# Joust fails: 0 <= 1
 	game.queue_actions(game.player1, [JOUST & Give(game.player1, TARGET_DUMMY)])
 	assert not game.player1.hand.filter(id=TARGET_DUMMY)
+	
 
 
 def test_mana():

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -279,8 +279,13 @@ def test_freeze():
 	game = prepare_game()
 	flameimp = game.current_player.give("EX1_319")
 	flameimp.play()
+	wisp = game.current_player.give(WISP)
+	wisp.play()
+	wisp2 = game.current_player.give(WISP)
+	wisp2.play()
 	game.end_turn()
-
+	
+	# Unfreeze at end of owner's turn, if it could have attacked (but didn't).
 	frostshock = game.current_player.give("CS2_037")
 	frostshock.play(target=flameimp)
 	assert flameimp.frozen
@@ -289,15 +294,28 @@ def test_freeze():
 	assert flameimp.frozen
 	assert not flameimp.can_attack()
 	game.end_turn()
+	
 	assert not flameimp.frozen
 	game.end_turn()
 
-	wisp = game.current_player.give(WISP)
-	wisp.play()
+	assert wisp.can_attack()
 	wisp.frozen = True
-	assert wisp.frozen
+	assert not wisp.can_attack()
+	
+	assert wisp2.can_attack()
+	wisp2.attack(target=game.current_player.opponent.hero)
+	assert not wisp2.can_attack()
+	wisp2.frozen = True
+	
+	wisp3 = game.current_player.give(WISP)
+	wisp3.play()
+	assert not wisp3.can_attack()
+	wisp3.frozen = True
+	assert wisp3.frozen
 	game.end_turn()
 	assert not wisp.frozen
+	assert wisp2.frozen
+	assert wisp3.frozen
 
 
 def test_graveyard_minions():

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -389,14 +389,28 @@ def test_mana():
 	game = prepare_game(game_class=Game)
 	footman = game.player1.give(GOLDSHIRE_FOOTMAN)
 	assert footman.cost == 1
+	assert game.player1.mana == 1
 	footman.play()
+	assert game.player1.mana == 0
 	assert footman.atk == 1
 	assert footman.health == 2
 	game.end_turn()
 
 	# Play the coin
 	coin = game.player2.hand.filter(id=THE_COIN)[0]
+	coin2 = game.player2.give(THE_COIN)
+	wisp = game.player2.give(WISP)
+	footman2 = game.player2.give(GOLDSHIRE_FOOTMAN)
+	assert game.player2.mana == 1
+	assert game.player2.temp_mana == 0
 	coin.play()
+	coin2.play()
+	assert game.player2.mana == 3
+	assert game.player2.temp_mana == 2
+	wisp.play()
+	assert game.player2.mana == 3
+	assert game.player2.temp_mana == 2
+	footman2.play()
 	assert game.player2.mana == 2
 	assert game.player2.temp_mana == 1
 	game.end_turn()


### PR DESCRIPTION
Exhausted characters do not unfreeze as normal.

Also minor bug fix in test_auras to actually assert instead of ignoring
the result of a comparison.

Additional asserts added to various tests as part of an effort to
clarify and harden the tests.