### PR TITLE
Ensure enchantment attributes are copied in ExactCopy

### DIFF
--- a/fireplace/dsl/picker.py
+++ b/fireplace/dsl/picker.py
@@ -94,5 +94,5 @@ class ExactCopy(Copy):
 		ret.damage = entity.damage
 		for buff in entity.buffs:
 			# Recreate the buff stack
-			entity.buff(ret, buff.id)
+			entity.buff(ret, buff.id, **vars(buff))
 		return ret

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5791,6 +5791,25 @@ def test_faceless_manipulator():
 	assert morphed.buffs
 
 
+def test_faceless_manipulator_voljin():
+	game = prepare_game()
+	wisp = game.player1.give(WISP)
+	wisp.play()
+	assert wisp.health == 1
+	voljin = game.player1.give("GVG_014")
+	voljin.play(target=wisp)
+	assert wisp.health == 2
+	assert voljin.health == 1
+	game.end_turn()
+
+	faceless = game.player2.give("EX1_564")
+	faceless.play(target=wisp)
+	morphed = game.player2.field[0]
+	assert wisp.health == 2
+	assert voljin.health == 1
+	assert morphed.health == 2
+
+
 def test_fel_reaver():
 	game = prepare_game()
 	expected_size = len(game.player1.deck)


### PR DESCRIPTION
This PR:
- transfers enchantment attributes in `ExactCopy`. Although enchantments were copied so far, their attributes weren't transferred. This could lead to errors when `ExactCopy`ing an enchantment with custom attributes (for example, using Faceless Manipulator on Vol'jin or the shadowed minion)
- adds a test for the Faceless Manipulator/Vol'jin interaction
- fixes #188