### PR TITLE
Fix Overload cost being removed by Counterspell and update test

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -218,10 +218,6 @@ class PlayableCard(BaseCard, TargetableByAuras):
 			# cf. test_knife_juggler()
 			self.game.process_deaths()
 
-		if self.overload:
-			self.log("%r overloads %s for %i", self, self.controller, self.overload)
-			self.controller.overloaded += self.overload
-
 	def destroy(self):
 		return self.game.queue_actions(self, [actions.Destroy(self), actions.Deaths()])
 

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -116,6 +116,9 @@ class BaseGame(Entity):
 			used_temp = min(player.temp_mana, cost)
 			cost -= used_temp
 			player.temp_mana -= used_temp
+		if card.overload:
+			self.log("%r overloads %s for %i", card, card.controller, card.overload)
+			card.controller.overloaded += card.overload
 		player.used_mana += cost
 		player.last_card_played = card
 		card.play_counter = self.play_counter

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1367,7 +1367,8 @@ def test_counterspell():
 	bolt.play(target=game.player1.hero)
 	assert not game.player1.secrets
 	assert game.player2.used_mana == 1
-	assert game.player2.overloaded == 0
+	# Overload is part of the manacost as of 10833
+	assert game.player2.overloaded == 1
 	assert game.player1.hero.health == 30
 
 


### PR DESCRIPTION
This PR:
- changes Overload to be locked at the same time we pay mana
- update Mirror Entity test
- fixes #222