### PR TITLE
Fix OneTurnEffects/Shrinkmeister

### DIFF
--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -284,7 +284,7 @@ class BaseGame(Entity):
 			if not character.num_attacks and not character.exhausted:
 				self.log("Freeze fades from %r", character)
 				character.frozen = False
-		for buff in self.current_player.entities.filter(one_turn_effect=True):
+		for buff in self.entities.filter(one_turn_effect=True):
 			self.log("Ending One-Turn effect: %r", buff)
 			buff.destroy()
 		self.begin_turn(self.current_player.opponent)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -851,6 +851,41 @@ def test_shield_slam():
 	assert wisp.dead
 
 
+def test_shrinkmeister():
+    game = prepare_game()
+    dummy = game.player1.give(TARGET_DUMMY)
+    dummy.play()
+    wisp = game.player1.give(WISP)
+    wisp.play()
+    boulderfist = game.player1.give("CS2_200")
+    boulderfist.play()
+    game.end_turn()
+
+    assert dummy.atk == 0
+    game.player2.give("GVG_011").play(target=dummy)
+    assert dummy.buffs
+    assert dummy.atk == 0
+
+    assert wisp.atk == 1
+    game.player2.give("GVG_011").play(target=wisp)
+    assert wisp.buffs
+    assert wisp.atk == 0
+
+    assert boulderfist.atk == 6
+    game.player2.give("GVG_011").play(target=boulderfist)
+    assert boulderfist.buffs
+    assert boulderfist.atk == 6 - 2
+    game.end_turn()
+
+    # ensure buffs are gone after end of turn
+    assert not dummy.buffs
+    assert dummy.atk == 0
+    assert not wisp.buffs
+    assert wisp.atk == 1
+    assert not boulderfist.buffs
+    assert boulderfist.atk == 6
+
+
 def test_siege_engine():
 	game = prepare_game(WARRIOR, WARRIOR)
 	engine = game.player1.give("GVG_086")


### PR DESCRIPTION
This PR:
- fixes the turn end cleanup to check all entities for the OneTurnEffect flag
- adds a test for Shrinkmeister
- fixes #227 