### PR TITLE
Remove pip install from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/virtualenv/python3.4
 script:
-  - pip install -r requirements.txt
+  # Travis will automatically detect requirements.txt and run pip install
   - ./bootstrap
   - ./setup.py install
   - py.test


### PR DESCRIPTION
Travis automatically runs pip install if a `requirements.txt` is detected. This leads to Travis currently running `pip install -r requirements.txt` twice.