### PR TITLE
Ensure multiple buffs are always removed on entity.clear_buffs()

### DIFF
--- a/fireplace/entity.py
+++ b/fireplace/entity.py
@@ -97,7 +97,7 @@ class BuffableEntity(BaseEntity):
 	def clear_buffs(self):
 		if self.buffs:
 			self.log("Clearing buffs from %r", self)
-			for buff in self.buffs:
+			for buff in self.buffs[:]:
 				buff.destroy()
 
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -594,6 +594,20 @@ def test_silence_deathrattle():
 	assert len(game.player1.field) == 0
 
 
+def test_silence_multiple_buffs():
+	game = prepare_game()
+	wisp = game.player1.give(WISP)
+	wisp.play()
+	assert wisp.atk == 1
+	# Play Blessing of Might (+3 attack) twice
+	game.player1.give("CS2_087").play(target=wisp)
+	assert wisp.atk == 1 + 3
+	game.player1.give("CS2_087").play(target=wisp)
+	assert wisp.atk == 1 + 3 + 3
+	game.player1.give(SILENCE).play(target=wisp)
+	assert wisp.atk == 1
+
+
 def test_spell_power():
 	game = prepare_game(HUNTER, HUNTER)
 


### PR DESCRIPTION
This PR:
- ensures that multiple buffs are always removed when iterating over the buff list in `clear_buffs()` by doing an in-place copy of the buff list
- adds a relevant test case (this failed beforehand)