### PR TITLE
Fix Mogor and Forgetful behaviour

### DIFF
--- a/fireplace/cards/gvg/neutral_legendary.py
+++ b/fireplace/cards/gvg/neutral_legendary.py
@@ -23,9 +23,7 @@ class GVG_111:
 
 # Mogor the Ogre
 class GVG_112:
-	events = Attack(MINION).on(Find(ENEMY_CHARACTERS - Attack.DEFENDER) & (
-		Retarget(Attack.ATTACKER, RANDOM(ENEMY_CHARACTERS - Attack.DEFENDER))
-	))
+	events = Attack(MINION).on(COINFLIP & Retarget(Attack.ATTACKER, RANDOM(ALL_CHARACTERS - Attack.DEFENDER - CONTROLLED_BY(Attack.ATTACKER))))
 
 
 # Foe Reaper 4000

--- a/fireplace/rules.py
+++ b/fireplace/rules.py
@@ -4,9 +4,7 @@ Base game rules (events, etc)
 from .cards.utils import *
 
 
-FORGETFUL = Attack(SELF).on(
-	COINFLIP & Retarget(SELF, RANDOM(ENEMY_CHARACTERS - Attack.DEFENDER))
-)
+FORGETFUL = Attack(SELF).on(COINFLIP & Retarget(SELF, RANDOM(ALL_CHARACTERS - Attack.DEFENDER - CONTROLLED_BY(SELF))))
 POISONOUS = Damage(MINION, None, SELF).on(Destroy(Damage.TARGETS))
 
 

--- a/tests/test_gvg.py
+++ b/tests/test_gvg.py
@@ -764,6 +764,18 @@ def test_mimirons_head_full_board():
 	assert game.player1.field[0].id == "GVG_111t"
 
 
+def test_mogor_the_ogre():
+	game = prepare_game()
+	mogor = game.player1.give("GVG_112").play()
+	game.end_turn()
+
+	wisp = game.player2.give(WISP).play()
+	game.end_turn(); game.end_turn()
+
+	wisp.attack(game.player1.hero)
+	assert (mogor.health == 5 and wisp.dead) ^ (game.player1.hero.health == 29 and not wisp.dead)
+
+
 def test_neptulon():
 	game = prepare_game()
 	game.player1.discard_hand()


### PR DESCRIPTION
- Adds a coin flip to Mogor's effect
- Ensures minions not on Mogor's team are retargeted correctly
- Adds a test for Mogor
- Stops forgetful minions from triggering when there is no other target

Previously minions would only attack Mogor's enemies, which could potentially include themself or teammates.
It's probably possible to implement Mogor more cleanly than having an two checks for friendly and enemy minions, but I wasn't able to figure that out.