### PR TITLE
Fix cost_mod + Aviana/Naga Sea Witch interaction

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -138,7 +138,7 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 
 	@property
 	def cost(self):
-		ret = self._getattr("cost", 0)
+		ret = 0
 		if self.zone == Zone.HAND:
 			mod = self.data.scripts.cost_mod
 			if mod is not None:
@@ -146,6 +146,7 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 				# evaluate() can return None if it's an Evaluator (Crush)
 				if r:
 					ret += r
+		ret = self._getattr("cost", ret)
 		return max(0, ret)
 
 	@cost.setter

--- a/tests/test_tgt.py
+++ b/tests/test_tgt.py
@@ -1,6 +1,30 @@
 from utils import *
 
 
+def test_aviana():
+	game = prepare_game()
+	aviana = game.player1.give("AT_045")
+	wisp1 = game.player1.give(WISP)
+	assert wisp1.cost == 0
+	deathwing = game.player1.give("NEW1_030")
+	assert deathwing.cost == 10
+	molten = game.player1.give("EX1_620")
+	assert molten.cost == 20
+	game.player1.give(MOONFIRE).play(game.player1.hero)
+	assert molten.cost == 19
+	aviana.play()
+	for minion in (wisp1, deathwing, molten):
+		assert minion.cost == 1
+
+	wisp2 = game.player2.give(WISP)
+	assert wisp2.cost == 0
+
+	aviana.destroy()
+	assert wisp1.cost == 0
+	assert deathwing.cost == 10
+	assert molten.cost == 19
+
+
 def test_beneath_the_grounds():
 	game = prepare_empty_game()
 	game.player2.discard_hand()


### PR DESCRIPTION
This PR:
- flips the order in which `cost_mod` and buffs are evaluated, so that buffs can always overwrite `cost_mod` scripts
- fixes #256, which fixes the failing Naga Sea Witch test in the LoE PR
- adds a test for Aviana