### PR TITLE
Fix Morph not transferring the zone position

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -846,6 +846,11 @@ class Morph(TargetedAction):
 
 	def do(self, source, target, card):
 		log.info("Morphing %r into %r", target, card)
+
+		# Transfer zone position _before_ we move target
+		index = target.controller.field.index(target)
+		card._summon_index = index
+
 		target.clear_buffs()
 		target_zone = target.zone
 		target.zone = Zone.SETASIDE

--- a/tests/test_blackrock.py
+++ b/tests/test_blackrock.py
@@ -184,7 +184,7 @@ def test_emperor_thaurissan_molten_recombobulator():
 	recomb = game.player1.give("GVG_108")
 	recomb.play(target=molten)
 	assert len(game.player1.field) == 2
-	assert game.player1.field[1].cost == 20
+	assert game.player1.field[0].cost == 20
 
 
 def test_fireguard_destroyer():

--- a/tests/test_classic.py
+++ b/tests/test_classic.py
@@ -1102,8 +1102,11 @@ def test_faceless_manipulator():
 	assert wisp.health == 1 + 2 - 1
 	game.end_turn()
 
+	dummy = game.player2.give(TARGET_DUMMY)
+	dummy.play()
 	faceless = game.player2.give("EX1_564")
-	faceless.play(target=wisp)
+	faceless.play(target=wisp, index=0)
+	assert game.player2.field[1] == dummy
 	morphed = game.player2.field[0]
 	assert morphed.id == WISP
 	assert morphed.buffs
@@ -3075,6 +3078,7 @@ def test_tinkmaster_overspark():
 	assert tinkmaster1 not in game.board
 	assert len(game.player1.field) == 2
 	assert game.board.contains("EX1_tk28") ^ game.board.contains("EX1_tk29")
+	assert game.player1.field[1].id == "EX1_083"
 
 
 def test_totemic_might():

--- a/tests/test_gvg.py
+++ b/tests/test_gvg.py
@@ -824,9 +824,9 @@ def test_recombobulator():
 	wisp.play()
 	recom = game.player1.give("GVG_108")
 	recom.play(target=wisp)
-	recom.destroy()
 
 	assert wisp not in game.player1.field
+	assert game.player1.field[1] == recom
 	assert game.player1.field[0].cost == 0
 
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -524,10 +524,10 @@ def test_morph():
 	game = prepare_game()
 	game.end_turn()
 
-	buzzard = game.player2.give("CS2_237")
-	buzzard.play()
 	wisp = game.player2.give(WISP)
 	wisp.play()
+	buzzard = game.player2.give("CS2_237")
+	buzzard.play()
 	game.end_turn()
 
 	game.player1.discard_hand()
@@ -537,7 +537,7 @@ def test_morph():
 	hex = game.player1.give("EX1_246")
 	hex.play(target=wisp)
 	assert not game.player2.field.contains(WISP)
-	assert game.player2.field.contains("hexfrog")
+	assert game.player2.field[0] == "hexfrog"
 	# Test that buzzard no longer draws on poly/hex (fixed in GVG)
 	assert not game.player2.hand
 	game.end_turn(); game.end_turn()


### PR DESCRIPTION
This is done by setting the cards \_summon_index before we move it into
play based on the zone position from the target before we _remove_ it
from play.

Fixes #276.