### PR TITLE
Reset _to_be_destroyed flag on entering PLAY and update tests

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -334,6 +334,11 @@ class LiveEntity(PlayableCard, Entity):
 		self.predamage = 0
 		self.turns_in_play = 0
 
+	def _set_zone(self, zone):
+		super()._set_zone(zone)
+		# See issue #283 (Malorne, Anu'barak)
+		self._to_be_destroyed = False
+
 	@property
 	def immune(self):
 		if self.immune_while_attacking and self.attacking:

--- a/tests/test_gvg.py
+++ b/tests/test_gvg.py
@@ -632,13 +632,23 @@ def test_malganis():
 def test_malorne():
 	game = prepare_empty_game()
 	assert len(game.player1.deck) == 0
-	malorne = game.player1.give("GVG_035")
-	malorne.play()
-	malorne.destroy()
-	assert len(game.player1.deck) == 1
-	game.player1.draw()
-	assert len(game.player1.hand) == 1
-	assert game.player1.hand[0].id == "GVG_035"
+	game.player1.give("GVG_035")
+	for i in range(3):
+		malorne = game.player1.hand[0]
+		assert malorne.id == "GVG_035"
+		malorne.play()
+		assert len(game.player1.field) == 1
+		assert len(game.player1.hand) == 0
+		assert len(game.player1.deck) == 0
+		malorne.destroy()
+		assert len(game.player1.field) == 0
+		assert len(game.player1.deck) == 1
+		assert len(game.player1.hand) == 0
+		game.end_turn(); game.end_turn()
+
+		assert len(game.player1.field) == 0
+		assert len(game.player1.deck) == 0
+		assert len(game.player1.hand) == 1
 
 
 def test_mechwarper():

--- a/tests/test_tgt.py
+++ b/tests/test_tgt.py
@@ -1,6 +1,30 @@
 from utils import *
 
 
+def test_anubarak():
+	game = prepare_empty_game()
+	anubarak = game.player1.give("AT_036")
+	anubarak.play()
+	game.player1.discard_hand()
+	assert len(game.player1.field) == 1
+	assert len(game.player1.hand) == 0
+	anubarak.destroy()
+	assert len(game.player1.field) == 1
+	assert len(game.player1.hand) == 1
+	token = game.player1.field[0]
+	assert token.id == "AT_036t"
+	anubarak = game.player1.hand[0]
+	assert anubarak.id == "AT_036"
+	game.end_turn(); game.end_turn()
+
+	# Test for issue #283: play Anub'arak again
+	anubarak.play()
+	assert len(game.player1.field) == 2
+	assert anubarak in game.player1.field
+	assert token in game.player1.field
+	assert len(game.player1.hand) == 0
+
+
 def test_aviana():
 	game = prepare_game()
 	aviana = game.player1.give("AT_045")


### PR DESCRIPTION
Fixes #283. Previously, we would not reset the flag leading to the minion being redestroyed immediately on play.