### PR TITLE
Create .editorconfig file for (among other things) proper tab size on Github

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{sh,py}]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
Github respects editorconfig indent_size, so tabs show up as 4 correctly (instead of 8 by default).