### PR TITLE
Fix for mulligan phase coming on turn 1 after first card is drawn

### DIFF
--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -254,13 +254,21 @@ class BaseGame(Entity):
 		for player in self.players:
 			player.prepare_for_game()
 
-	def start(self):
+	def start(self, start_first_turn = None):
 		self.log("Starting game %r", self)
 		self.state = State.RUNNING
 		self.step = Step.BEGIN_DRAW
 		self.zone = Zone.PLAY
 		self.prepare()
 		self.manager.start_game()
+
+		if start_first_turn is None:
+			start_first_turn = True
+
+		if start_first_turn:
+			self.first_turn()
+
+	def first_turn(self):
 		self.begin_turn(self.player1)
 
 	def end_turn(self):
@@ -331,8 +339,8 @@ class CoinRules:
 		self.log("Tossing the coin... %s wins!", winner)
 		return winner, winner.opponent
 
-	def start(self):
-		super().start()
+	def start(self, start_first_turn = None):
+		super().start(start_first_turn)
 		self.log("%s gets The Coin (%s)", self.player2, THE_COIN)
 		self.player2.give(THE_COIN)
 
@@ -347,7 +355,7 @@ class MulliganRules:
 		from .actions import MulliganChoice
 
 		self.next_step = Step.BEGIN_MULLIGAN
-		super().start()
+		super().start(False)
 
 		self.log("Entering mulligan phase")
 		self.step, self.next_step = self.next_step, Step.MAIN_READY

--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -324,6 +324,8 @@ class Kettle(socketserver.BaseRequestHandler):
 		for player in game.players:
 			player.choice = None
 
+		game.first_turn()
+
 		return manager
 
 

--- a/tests/full_game.py
+++ b/tests/full_game.py
@@ -24,6 +24,8 @@ def play_full_game():
 		cards_to_mulligan = random.sample(player.choice.cards, mull_count)
 		player.choice.choose(*cards_to_mulligan)
 
+	game.first_turn()
+
 	while True:
 		player = game.current_player
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,6 +91,7 @@ def prepare_game(hero1=None, hero2=None, exclude=(), game_class=BaseTestGame):
 	game = game_class(players=(player1, player2))
 	game.start()
 	_empty_mulligan(game)
+	game.first_turn()
 
 	return game
 
@@ -105,5 +106,6 @@ def prepare_empty_game(hero1=None, hero2=None, game_class=BaseTestGame):
 	game = game_class(players=(player1, player2))
 	game.start()
 	_empty_mulligan(game)
+	game.first_turn()
 
 	return game


### PR DESCRIPTION
The current order of execution when a game starts via game.start() is as follows (run full_game.py to reproduce):

1. The 'start first' coin is tossed and player X wins
2. Player X draws 3 cards
3. Player Y draws 4 cards
4. Turn 1 starts
5. Player X draws a card
6. Mulligan phase starts. Player Y gets the coin
7. Both players are given the opportunity to mulligan all 4 cards they have
8. Mulligan phase ends

This PR modifies the code flow to allow the mulligan to complete before turn 1 starts and the first regular start-of-turn card is drawn.

Game gets a new method first_turn() which must be called by the client code after game.start() and after the mulligan (player.choice.choose...) to trigger the start of turn 1.

Best regards,

Katy.
