### PR TITLE
Fix choosing Discover cards at end of turn

### DIFF
--- a/tests/full_game.py
+++ b/tests/full_game.py
@@ -45,18 +45,18 @@ def play_full_game():
 					target = random.choice(card.targets)
 				print("Playing %r on %r" % (card, target))
 				card.play(target=target)
+
+				if player.choice:
+					choice = random.choice(player.choice.cards)
+					print("Choosing card %r" % (choice))
+					player.choice.choose(choice)
+
 				continue
 
 		# Randomly attack with whatever can attack
 		for character in player.characters:
 			if character.can_attack():
 				character.attack(random.choice(character.targets))
-			continue
-
-		if player.choice:
-			choice = random.choice(player.choice.cards)
-			print("Choosing card %r" % (choice))
-			player.choice.choose(choice)
 			continue
 
 		game.end_turn()


### PR DESCRIPTION
full_game.py has a bug which causes card selections for eg. Discover not to occur until the end of the turn, after other cards are played and attacks performed. This change causes Discover card selections to be made at the time the cards is played before continuing the turn in full_game.py.

(Note: the selected card still cannot be played on the same turn due to the fact the card draw happens inside the player's hand iteration loop)
