### PR TITLE
Make Discover cards offer correct weighted distribution of choices from correct card pools

### DIFF
--- a/fireplace/cards/league/adventure.py
+++ b/fireplace/cards/league/adventure.py
@@ -16,17 +16,17 @@ class LOEA02_02h:
 
 # Wish for Power
 class LOEA02_03:
-	play = DISCOVER(RandomSpell())
+	play = DISCOVER(RandomDiscover(type=CardType.SPELL))
 
 
 # Wish for Valor
 class LOEA02_04:
-	play = DISCOVER(RandomCollectible(cost=4))
+	play = DISCOVER(RandomDiscover(cost=4))
 
 
 # Wish for Glory
 class LOEA02_05:
-	play = DISCOVER(RandomMinion())
+	play = DISCOVER(RandomDiscover(type=CardType.MINION))
 
 
 # Wish for More Wishes

--- a/fireplace/cards/league/collectible.py
+++ b/fireplace/cards/league/collectible.py
@@ -6,12 +6,12 @@ from ..utils import *
 
 # Ethereal Conjurer
 class LOE_003:
-	play = DISCOVER(RandomSpell())
+	play = DISCOVER(RandomDiscover(type=CardType.SPELL))
 
 
 # Museum Curator
 class LOE_006:
-	play = DISCOVER(RandomCollectible(deathrattle=True))
+	play = DISCOVER(RandomDiscover(deathrattle=True))
 
 
 # Obsidian Destroyer
@@ -68,12 +68,12 @@ class LOE_020:
 
 # Dark Peddler
 class LOE_023:
-	play = DISCOVER(RandomCollectible(cost=1))
+	play = DISCOVER(RandomDiscover(cost=1))
 
 
 # Jeweled Scarab
 class LOE_029:
-	play = DISCOVER(RandomCollectible(cost=3))
+	play = DISCOVER(RandomDiscover(cost=3))
 
 
 # Naga Sea Witch
@@ -84,7 +84,7 @@ class LOE_038:
 # Gorillabot A-3
 class LOE_039:
 	powered_up = Find(FRIENDLY_MINIONS + MECH - SELF)
-	play = powered_up & DISCOVER(RandomMech())
+	play = powered_up & DISCOVER(RandomDiscover(race=Race.MECHANICAL))
 
 
 # Huge Toad
@@ -94,7 +94,7 @@ class LOE_046:
 
 # Tomb Spider
 class LOE_047:
-	play = DISCOVER(RandomBeast())
+	play = DISCOVER(RandomDiscover(race=Race.BEAST))
 
 
 # Mounted Raptor
@@ -283,10 +283,10 @@ class LOE_115:
 	choose = ("LOE_115a", "LOE_115b")
 
 class LOE_115a:
-	play = DISCOVER(RandomMinion())
+	play = DISCOVER(RandomDiscover(type=CardType.MINION))
 
 class LOE_115b:
-	play = DISCOVER(RandomSpell())
+	play = DISCOVER(RandomDiscover(type=CardType.SPELL))
 
 
 ##

--- a/fireplace/cards/utils.py
+++ b/fireplace/cards/utils.py
@@ -10,6 +10,7 @@ from ..events import *
 # This needs to be Summon, because of Summon from the hand
 REMOVED_IN_PLAY = Summon(PLAYER, OWNER).after(Destroy(SELF))
 
+FRIENDLY_CLASS = Attr(FRIENDLY_HERO, GameTag.CLASS)
 ENEMY_CLASS = Attr(ENEMY_HERO, GameTag.CLASS)
 
 
@@ -31,6 +32,21 @@ FULL_HAND = Count(FRIENDLY_HAND) == 10
 HOLDING_DRAGON = Find(FRIENDLY_HAND + DRAGON - SELF)
 
 DISCOVER = lambda *args: Discover(CONTROLLER, *args)
+
+# Determine which class's cards to use in the card pool when a Discover choice is started
+def get_discover_class_source(entities, source):
+	if entities.current_player.hero.data.card_class != CardClass.NEUTRAL:
+		return [entities.current_player.hero]
+
+	if source.data.card_class != CardClass.NEUTRAL:
+		return [source]
+
+	from .. import cards
+	return [cards.db[random.choice(cards.filter(collectible=True, type=CardType.HERO))]]
+
+# The class card type to use for the next Discover action (takes non-standard heroes into account)
+FRIENDLY_DISCOVER_CLASS = Attr(FuncSelector(get_discover_class_source), GameTag.CLASS)
+
 
 # 50% chance to attack the wrong enemy.
 FORGETFUL = Attack(SELF).on(COINFLIP & Retarget(SELF, RANDOM(ALL_CHARACTERS - Attack.DEFENDER - CONTROLLED_BY(SELF))))

--- a/fireplace/dsl/random_picker.py
+++ b/fireplace/dsl/random_picker.py
@@ -1,7 +1,7 @@
 import random
-from hearthstone.enums import CardType, Race, Rarity
+from hearthstone.enums import CardClass, CardType, Race, Rarity
 from .lazynum import LazyValue
-
+from ..cards import utils
 
 class RandomCardPicker(LazyValue):
 	"""
@@ -12,45 +12,125 @@ class RandomCardPicker(LazyValue):
 		self.filters = filters
 		self.count = 1
 		self._cards = None
-		self.lazy_filters = False
-		for v in filters.values():
-			if isinstance(v, LazyValue):
-				self.lazy_filters = True
-				break
+		self._source = None
 
 	def __repr__(self):
 		return "%s(%r)" % (self.__class__.__name__, self.filters)
 
 	def __mul__(self, other):
 		ret = self.__class__(*self.args, **self.filters)
+		ret._cards = self._cards
+		ret._source = self._source
 		ret.count = other
 		return ret
-
-	@property
-	def cards(self):
-		if self._cards is None:
-			self._cards = self._filter_cards(self.filters)
-		return self._cards
 
 	def _filter_cards(self, filters):
 		from .. import cards
 		return cards.filter(**filters)
 
-	def get_cards(self, source):
-		filters = self.filters.copy()
+	def _get_lazy_filtered_cards(self, source, filters):
+		newFilters = filters.copy()
 		# Iterate through the filters, evaluating the LazyValues as we go
-		for k, v in filters.items():
+		for k, v in newFilters.items():
 			if isinstance(v, LazyValue):
-				filters[k] = v.evaluate(source)
-		return self._filter_cards(filters)
+				newFilters[k] = v.evaluate(source)
+		return self._filter_cards(newFilters)
 
-	def evaluate(self, source) -> str:
-		if self.lazy_filters:
-			# If the card has lazy filters, we need to evaluate them
-			cards = self.get_cards(source)
-		else:
-			cards = self.cards
+	def find_cards(self, source=None, **filters):
+		if len(filters)==0:
+			filters = self.filters
+
+		if source is None:
+			source = self._source
+
+		if self._cards is None or filters != self.filters or source != self._source:
+			lazy_filters = False
+			for v in filters.values():
+				if isinstance(v, LazyValue):
+					lazy_filters = True
+					break
+
+			if lazy_filters:
+				# If the card has lazy filters, we need to evaluate them
+				self._cards = self._get_lazy_filtered_cards(source, filters)
+			else:
+				self._cards = self._filter_cards(filters)
+
+		return self._cards
+
+	def evaluate(self, source, cards=None) -> str:
+		cards = cards or self.find_cards(source)
 		ret = random.sample(cards, self.count)
+		return [source.controller.card(card, source=source) for card in ret]
+
+
+# get random card(s) matching the filter in the constructor plus one of several weighted filters
+class RandomCardWeighted(RandomCardPicker):
+	def __init__(self, *args, **filters):
+		self._weights = []
+		self._weightedfilters = []
+
+		super().__init__(*args, **filters)
+
+	# add a filter set
+	def add(self, weight, **filters):
+		self._weights.append(weight)
+		self._weightedfilters.append(filters)
+		return self
+
+	# select number of cards to fetch (overrides base __mul__ because creating a new object will cause the derived members to be lost)
+	def __mul__(self, other):
+		ret = super().__mul__(other)
+		ret._weights = self._weights
+		ret._weightedfilters = self._weightedfilters
+		return ret
+
+	# This picks from a single combined card pool without replacement, weighting each filtered set of cards against the total
+	def evaluate(self, source):
+
+		# add the global filters to each set of filters
+		self._weightedfilters[:] = [{ **x, **self.filters } for x in self._weightedfilters]
+
+		# get all the cards matching each set of filters and create the weight line
+		# (user does not have to normalize weighting from 0-1)
+		cardlist = []
+		weightedsegmentstarts = [0] * len(self._weightedfilters)
+		weightlinelength = 0
+
+		for i, f in enumerate(self._weightedfilters):
+			nextset = self.find_cards(source, **f)
+			weightedsegmentstarts[i] = len(cardlist)
+			cardlist += nextset
+			# higher weighted sets (segments) occupy more space per item on the weight line
+			weightlinelength += len(nextset) * self._weights[i]
+
+		ret = []
+
+		# for each card
+		for c in range(0, self.count):
+
+			# pick a point along the weight line
+			r = random.random() * weightlinelength
+			pos = 0
+
+			# figure out which segment it's in
+			for i, w in enumerate(self._weights):
+				segmentarraylength = ((len(cardlist) if i == len(self._weights)-1 else weightedsegmentstarts[i+1]) - weightedsegmentstarts[i])
+				segmentlinelength = segmentarraylength * w
+				# it's in this segment, find exact card
+				if (r < pos + segmentlinelength):
+					# find percentage along this segment we're at
+					spc = (r - pos) / segmentlinelength
+					# map percentage to array index, add card to selection, remove from weight line
+					ret.append(cardlist.pop(weightedsegmentstarts[i] + int(spc * segmentarraylength)))
+					# update weights
+					weightlinelength -= w
+					weightedsegmentstarts[i+1:] = [x-1 for x in weightedsegmentstarts[i+1:]]
+
+					break
+
+				pos += segmentlinelength
+
 		return [source.controller.card(card, source=source) for card in ret]
 
 
@@ -65,15 +145,14 @@ RandomTotem = lambda *a, **kw: RandomCardPicker(*a, race=Race.TOTEM)
 RandomWeapon = lambda *a, **kw: RandomCollectible(*a, type=CardType.WEAPON, **kw)
 RandomLegendaryMinion = lambda *a, **kw: RandomMinion(*a, rarity=Rarity.LEGENDARY, **kw)
 RandomSparePart = lambda: RandomCardPicker(spare_part=True)
+RandomDiscover = lambda *a, **kw: RandomCardWeighted(*a, collectible=True, **kw).add(1, card_class=CardClass.NEUTRAL).add(4, card_class=utils.FRIENDLY_DISCOVER_CLASS)
 
 
 class RandomEntourage(RandomCardPicker):
-	def evaluate(self, source, **kwargs):
-		self._cards = source.entourage
-		return super().evaluate(source, **kwargs)
+	def evaluate(self, source):
+		return super().evaluate(source, source.entourage)
 
 
 class RandomID(RandomCardPicker):
-	def evaluate(self, source, **kwargs):
-		self._cards = self.args
-		return super().evaluate(source, **kwargs)
+	def evaluate(self, source):
+		return super().evaluate(source, self.args)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,119 @@
+from utils import *
+
+DISCOVER_TEST_CLASS_STR = MAGE
+DISCOVER_TEST_CLASS = CardClass.MAGE
+
+MUSEUM_CURATOR = "LOE_006"
+DARK_PEDDLER = "LOE_023"
+JEWELED_SCARAB = "LOE_029"
+
+
+def _setup_normal():
+	return prepare_empty_game(DISCOVER_TEST_CLASS_STR, DISCOVER_TEST_CLASS_STR)
+
+
+def _setup_ragnaros():
+	game = prepare_empty_game(DISCOVER_TEST_CLASS_STR, DISCOVER_TEST_CLASS_STR)
+
+	majordomo = game.player1.give("BRM_027")
+	majordomo.play()
+	majordomo.destroy()
+	assert game.player1.hero.id == "BRM_027h"
+	game.end_turn(); game.end_turn()
+
+	return game
+
+
+def _setup_jaraxxus():
+	game = prepare_empty_game(DISCOVER_TEST_CLASS_STR, DISCOVER_TEST_CLASS_STR)
+
+	jaraxxus = game.player1.give("EX1_323")
+	jaraxxus.play()
+	assert game.player1.hero.id == "EX1_323h"
+	game.end_turn(); game.end_turn()
+
+	return game
+
+
+def _discover_and_trash(game, card):
+	game.player1.choice.choose(random.choice(game.player1.choice.cards))
+	card.destroy()
+	game.player1.discard_hand()
+	game.end_turn(); game.end_turn()
+	
+
+def _discover_expecting_class(game, cardid, expectedclass, depth=None):
+	if depth is None:
+		depth = 10
+
+	for d in range(depth):
+		discover_card = game.player1.give(cardid)
+		discover_card.play()
+		for card in game.player1.choice.cards:
+			assert card.data.card_class == expectedclass or card.data.card_class == CardClass.NEUTRAL
+
+		_discover_and_trash(game, discover_card)
+
+
+def _discover_disproving_class(game, cardid, disproveclass, depth=None):
+	if depth is None:
+		depth = 100
+
+	success = False
+	for d in range(depth):
+		discover_card = game.player1.give(cardid)
+		discover_card.play()
+		for card in game.player1.choice.cards:
+			if card.data.card_class != disproveclass and card.data.card_class != CardClass.NEUTRAL:
+				success = True
+				break
+
+		_discover_and_trash(game, discover_card)
+
+		if success:
+			break
+
+	assert success
+
+
+def test_class_discover_as_ragnaros():
+	game = _setup_ragnaros()
+	_discover_expecting_class(game, DARK_PEDDLER, CardClass.WARLOCK)
+	_discover_expecting_class(game, MUSEUM_CURATOR, CardClass.PRIEST)
+
+
+def test_neutral_discover_as_ragnaros():
+	game = _setup_ragnaros()
+	_discover_disproving_class(game, JEWELED_SCARAB, DISCOVER_TEST_CLASS)
+
+
+def test_class_discover_as_jaraxxus():
+	game = _setup_jaraxxus()
+	_discover_expecting_class(game, MUSEUM_CURATOR, CardClass.WARLOCK)
+
+
+def test_neutral_discover_as_jaraxxus():
+	game = _setup_jaraxxus()
+	_discover_expecting_class(game, JEWELED_SCARAB, CardClass.WARLOCK)
+
+
+def test_class_discover_as_collectible_hero():
+	game = _setup_normal()
+	_discover_expecting_class(game, DARK_PEDDLER, DISCOVER_TEST_CLASS)
+	_discover_expecting_class(game, MUSEUM_CURATOR, DISCOVER_TEST_CLASS)
+
+
+def test_neutral_discover_as_collectible_hero():
+	game = _setup_normal()
+	_discover_expecting_class(game, JEWELED_SCARAB, DISCOVER_TEST_CLASS)
+	
+
+def main():
+	for name, f in globals().items():
+		if name.startswith("test_") and callable(f):
+			f()
+	print("All tests ran OK")
+
+
+if __name__ == "__main__":
+	main()

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -29,7 +29,7 @@ def test_empty_selector():
 
 def test_random_card_picker():
 	picker = RandomCardPicker()
-	ids = picker.cards
+	ids = picker.find_cards()
 	for id in ids:
 		card = Card(id)
 		assert card.type is not CardType.HERO


### PR DESCRIPTION
Add RandomCardWeighted() generalised card picker to pick from a merged card pool created from several sets of weighted filters
Add RandomDiscover() card picker
Update LoE collectible and adventure card definitions
Add FRIENDLY_DISCOVER_CLASS helper in cards.utils
RandomCardPicker() card pool can be overridden by passing a new card pool in evaluate(cards=...)
Discover weighting and class tests added (test_discover.py)
...

Discover cards usually offer a choice of 3 cards sampled from a weighted card pool without replacement, consisting of neutral collectible cards with a weighting of 1 and class collectible cards with a weighting of 4.

The existing fireplace code by default offers a choice of 3 cards sampled from a non-weighted card pool without replacement, consisting of neutral collectible cards and class collectible cards from all available classes.

This PR modifies the behaviour of the Discover mechanic's generation of card pools and weighted selection to match the behaviour of Discover in Heearthstone.

The new card picker RandomCardWeighted() allows an arbitrary number of card pools (defined by filter sets) to be chained together into a single card pool, with each sub-pool given a weight. This is a generalised solution to the Discover mechanic which can be re-used in future for potential new mechanics not yet introduced.

The new card picker RandomDiscover() implements the default Discover mechanic as follows:

RandomCardWeighted(*a, collectible=True, **kw).add(1, card_class=CardClass.NEUTRAL).add(4, card_class=utils.FRIENDLY_DISCOVER_CLASS)

This creates a weighted selection from two card pools: neutral cards and the class to be used for the  Discover mechanic, with the class cards weighted 4 times higher than the neutral cards. Any number of .add(filter=....) can be appended to add new card pools as desired.

FRIENDLY_DISCOVER_CLASS will lazily determine the class to be used for the Discover class card pool generation, according to the following rules:

1. Use the player's class if available (covers collectible heroes and Jaraxxus)
2. Use the card's class if not neutral (causes class cards of the Discover card's class to be used when playing as Ragnaros or other non-collectible non-standard-class heroes)
3. Uses a random collectible hero's class otherwise (causes neutral cards of a random collectible hero's class to be used when playing as Ragnaros or other non-collectible non-standard-class heroes)

FuncSelector(get_discover_class_source) encapsulates the logic for this, returning either the player's hero, the class card or a random collectible hero as appropriate. FRIENDLY_DISCOVER_CLASS inspects the GameTag.CLASS on the returned item to determine the class to use.

The new test series in test_discover.py tests to ensure that the correct class cards are being picked with various combinations of heroes and neutral or class Discover cards being used.

Katy
