### PR TITLE
Fix RandomCardPicker weight list shallow copy

### DIFF
--- a/fireplace/dsl/random_picker.py
+++ b/fireplace/dsl/random_picker.py
@@ -23,13 +23,17 @@ class RandomCardPicker(LazyValue):
 	# select number of cards to fetch
 	def __mul__(self, other):
 		ret = copy(self)
+		ret.weight = list(self.weights)
+		ret.weightedfilters = list(self.weightedfilters)
 		ret.count = other
 		return ret
 
 	# add a filter set
 	def copy_with_weighting(self, weight, **filters):
 		ret = copy(self)
+		ret.weights = list(self.weights)
 		ret.weights.append(weight)
+		ret.weightedfilters = list(self.weightedfilters)
 		ret.weightedfilters.append(filters)
 		return ret
 


### PR DESCRIPTION
The weighted picker code has a bug which causes the weight lists to be shallow copied instead of deep copied. This can cause problems when pickers are re-used.

I have copied the lists individually rather than using deepcopy() below as the lists are guaranteed not to have circular references.

This PR is a re-requisite for the forthcoming Discover PR.
