### PR TITLE
Make Discover choose correct class and card distributions

### DIFF
--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -92,6 +92,10 @@ def random_draft(card_class: CardClass, exclude=[]):
 	return deck
 
 
+def random_class():
+	return CardClass(random.randint(2, 10))
+
+
 def get_script_definition(id):
 	"""
 	Find and return the script definition for card \a id

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -279,6 +279,28 @@ def test_discard_enchanted_cards():
 	assert not game.player1.hand
 
 
+def test_discover():
+	# TODO: use different classes for each player and force player 1 to go first
+	game = prepare_empty_game(CardClass.PRIEST, CardClass.PRIEST)
+
+	# Museum Curator
+	assert game.player1.choice == None
+	curator = game.player1.give("LOE_006")
+	curator.play()
+	assert not game.player1.choice == None
+	assert len(game.player1.choice.cards) == 3
+
+	for card in game.player1.choice.cards:
+		assert (fireplace.cards.db[card].card_class == CardClass.NEUTRAL
+				or fireplace.cards.db[card].card_class == CardClass.PRIEST)
+		assert fireplace.cards.db[card].deathrattle == True
+
+	choice = random.choice(game.player1.choice.cards)
+	game.player1.choice.choose(choice)
+	assert game.player1.choice == None
+	assert len(game.player1.hand) == 1
+
+
 def test_divine_shield():
 	game = prepare_game(CardClass.MAGE, CardClass.MAGE)
 	squire = game.player1.give("EX1_008")


### PR DESCRIPTION
DISCOVER(x) / Discover(x) will now take filter x and transform it as follows:

x restricted to neutral class - weight 1
x restricted to discover class - weight 4

where discover class is the player's hero for all heroes except Ragnaros, the card class if Ragnaros, and a random collectible hero if Ragnaros and the card class is neutral

The cards are aggregated into a pool and random sampled without replacement.

This should replicate the real behaviour of Hearthstone.

New generic test added to test_mechanics.py

Tested heuristcally for all possible combinations of collectible hero, Jaraxxus, Raganaros, neutral and class cards (code not included as per earlier request)

Note there is a bug in Hearthstone 5 (or a feature...) whereby Discover cards can offer duplicates. The code in this PR will *not* offer duplicates.
