### PR TITLE
Integrate pytest-benchmark, add selector and full_game tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 script:
   # Travis will automatically detect requirements.txt and run pip install
   - ./setup.py install
-  - py.test
+  - py.test --benchmark-max-time=0.5
 notifications:
   email:
     on_failure: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 hearthstone
 pytest
+pytest-benchmark

--- a/tests/test_micro_bench.py
+++ b/tests/test_micro_bench.py
@@ -1,0 +1,24 @@
+from full_game import test_full_game
+from utils import *
+
+
+def run_selector(game, alex):
+	selector = PIRATE | DRAGON + MINION
+	assert len(selector.eval(game.player1.hand, game.player1)) >= 1
+
+	selector = IN_HAND + DRAGON + FRIENDLY
+	targets = selector.eval(game, game.player1)
+	assert len(targets) == 1
+	assert targets[0] == alex
+
+
+def test_selectors(benchmark):
+	game = prepare_game()
+	game.player1.discard_hand()
+	alex = game.player1.give("EX1_561")
+
+	benchmark(run_selector, game, alex)
+
+
+def test_fullgame(benchmark):
+	benchmark(test_full_game)


### PR DESCRIPTION
Closes #314 

Note that this adds about ~2 seconds to a full `py.test` run, between warming up the benchmark and actually running through it. Seems reasonable given that the tests generally take ~10 seconds.