### PR TITLE
Specify install and test deps in setup.py and use it for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/virtualenv/python3.5
 install:
-  - pip install -r requirements.txt
-  - pip install pytest-benchmark
-  - ./setup.py install
+  - pip install .[tests] pytest-benchmark
 script:
   - py.test
   - py.test tests/benchmarks.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 hearthstone
-pytest

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@ import os.path
 import fireplace
 from setuptools import setup, find_packages
 
-
-README = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
+_basedir = os.path.dirname(__file__)
+README = open(os.path.join(_basedir, "README.md")).read()
+with open(os.path.join(_basedir, "requirements.txt")) as f:
+	requirements = f.read().splitlines()
 
 CLASSIFIERS = [
 	"Development Status :: 2 - Pre-Alpha",
@@ -17,12 +19,15 @@ CLASSIFIERS = [
 	"Topic :: Games/Entertainment :: Simulation",
 ]
 
+tests_require = ["pytest"]
 
 setup(
 	name="fireplace",
 	version=fireplace.__version__,
 	packages=find_packages(exclude="tests"),
-	tests_require=["pytest"],
+	install_requires=requirements,
+	tests_require=[tests_require],
+	extras_require={"tests": tests_require},
 	author=fireplace.__author__,
 	author_email=fireplace.__email__,
 	description="Pure-python Hearthstone re-implementation and simulator",


### PR DESCRIPTION
Update requirements.txt to only have install dependencies.

Note that this makes fireplace directly pip installable, as very Python packages require a separate `pip install -r requirements.txt` nowadays.

So `pip install git+https://github.com/jleclanche/fireplace.git#egg=fireplace` simply works (and so will `pip install fireplace` once it's on PyPI) and if you want pytest as well, you just add `[tests]` at the end.