### PR TITLE
Rework entity properties

### DIFF
--- a/fireplace/entity.py
+++ b/fireplace/entity.py
@@ -1,13 +1,140 @@
+import ast
 import uuid
+import sys
 from hearthstone.enums import CardType
 from . import logging
 
 
-class BaseEntity(object):
+class CalculatedProperty:
+	"""
+	A data descriptor intended for card attributes that are influenced
+	by buffs.
+
+	If the `eager` keyword argument is true, the value of the property is
+	computed each time it is accessed. Otherwise, it is computed every time it
+	is changed, or attached entities change their copy.
+	"""
+	__slots__ = ("_name", "_default", "_eager", "_xname", "_basename")
+
+	def __init__(self, default, *, eager=False):
+		self._name = None
+		self._default = default
+		self._eager = eager
+
+	def _setup(self, cls, name):
+		self._name = sys.intern(name)
+		self._xname = sys.intern("_" + name)
+		self._basename = sys.intern("!" + name)
+
+		setattr(cls, self._xname, self._default)
+
+		class _Calculated(type(self)):
+			__slots__ = ()
+
+			if self._eager:
+				def __get__(self, inst, owner):
+					return self._calculate(inst)
+			else:
+				"""
+				def __get__(self, inst, owner):
+					return inst.{self._xname}
+				def __set__(self, inst, v):
+					inst.{self._basename} = v
+					self.recalculate(inst)
+				"""
+				exec(compile(ast.fix_missing_locations(ast.Module([
+					ast.FunctionDef("__get__", ast.arguments([ast.arg("self", None), ast.arg("inst", None), ast.arg("owner", None)], None, [], [], None, []),
+					                [ast.Return(ast.Attribute(ast.Name("inst", ast.Load()), self._xname, ast.Load()))], [], None),
+					ast.FunctionDef("__set__", ast.arguments([ast.arg("self", None), ast.arg("inst", None), ast.arg("v", None)], None, [], [], None, []),
+					                [ast.Assign([ast.Attribute(ast.Name("inst", ast.Load()), self._basename, ast.Store())], ast.Name("v", ast.Load())),
+					                 ast.Expr(ast.Call(ast.Attribute(ast.Name("self", ast.Load()), "recalculate", ast.Load()), [ast.Name("inst", ast.Load())], []))], [], None)])),
+					"<generated code for %r>" % (self), "exec"))
+
+		self.__class__ = _Calculated
+
+	def __get__(self, inst, owner):
+		# XXX for documentation only
+		assert False, "you shouldn't call this"
+		if inst is None:
+			return self
+		if self._eager:
+			return self._calculate(inst)
+		return getattr(inst, self._xname)
+
+	def __set__(self, inst, v):
+		setattr(inst, self._basename, v)
+		self.recalculate(inst)
+
+	def _calculate(self, owner):
+		raise NotImplementedError
+
+	def recalculate(self, owner):
+		if not self._eager:
+			setattr(owner, self._xname, self._calculate(owner))
+		if owner.is_enchantment and getattr(owner, "owner", False):
+			self.recalculate(owner.owner)
+
+	def __repr__(self):
+		return "<CalculatedProperty %s>" % (self._name)
+
+
+class BooleanProperty(CalculatedProperty):
+	__slots__ = ()
+
+	def __init__(self, **kw):
+		super().__init__(False, **kw)
+
+	def _calculate(self, owner):
+		return (
+			getattr(owner, self._basename, False) or
+			any(getattr(buff, self._name, False) for buff in owner.buffs) or
+			any(getattr(slot, self._name, False) for slot in owner.slots) or
+			getattr(owner.data.scripts, self._name, lambda s, x: x)(self, False)
+		)
+
+
+class SlotProperty(CalculatedProperty):
+	__slots__ = ('_f',)
+
+	def __init__(self, f=any, **kw):
+		self._f = f
+		super().__init__(False, **kw)
+
+	def _calculate(self, owner):
+		return self._f(getattr(slot, self._name, False) for slot in owner.slots)
+
+
+class IntProperty(CalculatedProperty):
+	__slots__ = ()
+
+	def __init__(self, **kw):
+		super().__init__(0, **kw)
+
+	def _calculate(self, owner):
+		return max(owner._getattr(self._name, 0), 0)
+
+
+class EntityMeta(type):
+	def __init__(cls, name, bases, namespace):
+		for k, v in list(cls.__dict__.items()):
+			if not isinstance(v, CalculatedProperty):
+				continue
+			v._setup(cls, k)
+
+		properties = {}
+
+		for t in reversed(cls.mro()):
+			properties.update({ k: v for k, v in t.__dict__.items() if isinstance(v, CalculatedProperty) })
+
+		cls.properties = properties
+
+
+class BaseEntity(metaclass=EntityMeta):
 	base_events = []
 	logger = logging.log
 	ignore_scripts = False
 	type = CardType.INVALID
+	is_enchantment = False
 
 	def __init__(self):
 		self.manager = self.Manager(self)
@@ -91,7 +218,7 @@ class BuffableEntity(BaseEntity):
 		self.slots = []
 
 	def _getattr(self, attr, i):
-		i += getattr(self, "_" + attr, 0)
+		i += getattr(self, "!" + attr, 0)
 		for buff in self.buffs:
 			i = buff._getattr(attr, i)
 		for slot in self.slots:
@@ -100,49 +227,17 @@ class BuffableEntity(BaseEntity):
 			return i
 		return getattr(self.data.scripts, attr, lambda s, x: x)(self, i)
 
+	def calculate_buffs(self):
+		for k, v in self.properties.items():
+			v.recalculate(self)
+
 	def clear_buffs(self):
 		if self.buffs:
 			self.log("Clearing buffs from %r", self)
 			for buff in self.buffs[:]:
 				buff.remove()
+			self.calculate_buffs()
 
 
 class Entity(BuffableEntity):
 	pass
-
-
-def slot_property(attr, f=any):
-	@property
-	def func(self):
-		return f(getattr(slot, attr, False) for slot in self.slots)
-	return func
-
-
-def boolean_property(attr):
-	@property
-	def func(self):
-		return (
-			getattr(self, "_" + attr, False) or
-			any(getattr(buff, attr, False) for buff in self.buffs) or
-			any(getattr(slot, attr, False) for slot in self.slots) or
-			getattr(self.data.scripts, attr, lambda s, x: x)(self, False)
-		)
-
-	@func.setter
-	def func(self, value):
-		setattr(self, "_" + attr, value)
-
-	return func
-
-
-def int_property(attr):
-	@property
-	def func(self):
-		ret = self._getattr(attr, 0)
-		return max(0, ret)
-
-	@func.setter
-	def func(self, value):
-		setattr(self, "_" + attr, value)
-
-	return func

--- a/fireplace/player.py
+++ b/fireplace/player.py
@@ -6,23 +6,23 @@ from .aura import TargetableByAuras
 from .card import Card
 from .deck import Deck
 from .entity import Entity
-from .entity import slot_property
+from .entity import SlotProperty
 from .managers import PlayerManager
 from .utils import CardList
 
 
 class Player(Entity, TargetableByAuras):
 	Manager = PlayerManager
-	cant_overload = slot_property("cant_overload")
-	extra_battlecries = slot_property("extra_battlecries")
-	extra_deathrattles = slot_property("extra_deathrattles")
-	healing_double = slot_property("healing_double", sum)
-	hero_power_double = slot_property("hero_power_double", sum)
-	healing_as_damage = slot_property("healing_as_damage")
-	shadowform = slot_property("shadowform")
-	spellpower_double = slot_property("spellpower_double", sum)
-	spellpower_adjustment = slot_property("spellpower", sum)
-	spells_cost_health = slot_property("spells_cost_health")
+	cant_overload = SlotProperty()
+	extra_battlecries = SlotProperty()
+	extra_deathrattles = SlotProperty()
+	healing_double = SlotProperty(sum)
+	hero_power_double = SlotProperty(sum)
+	healing_as_damage = SlotProperty()
+	shadowform = SlotProperty()
+	spellpower_double = SlotProperty(sum)
+	spellpower_adjustment = SlotProperty(sum)
+	spells_cost_health = SlotProperty()
 	type = CardType.PLAYER
 
 	def __init__(self, name, deck, hero):


### PR DESCRIPTION
Replace the current system (which calculates on attribute access) with one that pre-calculates attributes. This makes attribute access faster, and with any luck decreases the overall number of times we need to
recalculate values.

This is not quite ready to be pulled—I'm still looking at ways of avoiding the code generation—but I think it's ready to be considered.
