### PR TITLE
Make play_full_game() return runtime in game.runtime

### DIFF
--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -1,4 +1,5 @@
 import random
+import time
 import os.path
 from bisect import bisect
 from importlib import import_module
@@ -177,6 +178,8 @@ def play_full_game():
 	game = Game(players=(player1, player2))
 	game.start()
 
+	start = time.time()
+
 	for player in game.players:
 		print("Can mulligan %r" % (player.choice.cards))
 		mull_count = random.randint(0, len(player.choice.cards))
@@ -187,6 +190,8 @@ def play_full_game():
 		play_full_game_turn_loop(game)
 	except GameOver:
 		print("Game completed normally.")
+
+	game.runtime = time.time() - start
 
 	return game
 

--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from pkgutil import iter_modules
 from typing import List
 from xml.etree import ElementTree
+from fireplace.exceptions import GameOver
 from hearthstone.enums import CardType
 
 
@@ -182,6 +183,15 @@ def play_full_game():
 		cards_to_mulligan = random.sample(player.choice.cards, mull_count)
 		player.choice.choose(*cards_to_mulligan)
 
+	try:
+		play_full_game_turn_loop(game)
+	except GameOver:
+		print("Game completed normally.")
+
+	return game
+
+
+def play_full_game_turn_loop(game):
 	while True:
 		player = game.current_player
 

--- a/tests/full_game.py
+++ b/tests/full_game.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
 import sys; sys.path.append("..")
 from fireplace import cards
-from fireplace.exceptions import GameOver
 from fireplace.utils import play_full_game
 
 
 def test_full_game():
-	try:
-		play_full_game()
-	except GameOver:
-		print("Game completed normally.")
+	play_full_game()
 
 
 def main():


### PR DESCRIPTION
Store the game runtime excluding draft and initial setup in game.runtime when calling play_full_game()

Requires #359 to work
