### PR TITLE
Make test_full_game() show stats

### DIFF
--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -1,4 +1,5 @@
 import random
+import time
 import os.path
 from bisect import bisect
 from importlib import import_module
@@ -177,6 +178,8 @@ def play_full_game():
 	game = Game(players=(player1, player2))
 	game.start()
 
+	start = time.time()
+
 	for player in game.players:
 		print("Can mulligan %r" % (player.choice.cards))
 		mull_count = random.randint(0, len(player.choice.cards))
@@ -187,6 +190,8 @@ def play_full_game():
 		play_full_game_turn_loop(game)
 	except GameOver:
 		print("Game completed normally.")
+
+	game.runtime = time.time() - start
 
 	return game
 

--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -165,7 +165,7 @@ def weighted_card_choice(source, weights: List[int], card_sets: List[str], count
 	return [source.controller.card(card, source=source) for card in chosen_cards]
 
 
-def play_full_game():
+def play_full_game(output=True):
 	from .cards.heroes import MAGE, WARRIOR
 	from .game import Game
 	from .player import Player
@@ -181,22 +181,24 @@ def play_full_game():
 	start = time.time()
 
 	for player in game.players:
-		print("Can mulligan %r" % (player.choice.cards))
+		if (output):
+			print("Can mulligan %r" % (player.choice.cards))
 		mull_count = random.randint(0, len(player.choice.cards))
 		cards_to_mulligan = random.sample(player.choice.cards, mull_count)
 		player.choice.choose(*cards_to_mulligan)
 
 	try:
-		play_full_game_turn_loop(game)
+		play_full_game_turn_loop(game, output)
 	except GameOver:
-		print("Game completed normally.")
+		if (output):
+			print("Game completed normally.")
 
 	game.runtime = time.time() - start
 
 	return game
 
 
-def play_full_game_turn_loop(game):
+def play_full_game_turn_loop(game, output=True):
 	while True:
 		player = game.current_player
 
@@ -216,12 +218,14 @@ def play_full_game_turn_loop(game):
 					card = random.choice(card.choose_cards)
 				if card.has_target():
 					target = random.choice(card.targets)
-				print("Playing %r on %r" % (card, target))
+				if (output):
+					print("Playing %r on %r" % (card, target))
 				card.play(target=target)
 
 				if player.choice:
 					choice = random.choice(player.choice.cards)
-					print("Choosing card %r" % (choice))
+					if (output):
+						print("Choosing card %r" % (choice))
 					player.choice.choose(choice)
 
 				continue

--- a/fireplace/utils.py
+++ b/fireplace/utils.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from pkgutil import iter_modules
 from typing import List
 from xml.etree import ElementTree
+from fireplace.exceptions import GameOver
 from hearthstone.enums import CardType
 
 
@@ -182,6 +183,15 @@ def play_full_game():
 		cards_to_mulligan = random.sample(player.choice.cards, mull_count)
 		player.choice.choose(*cards_to_mulligan)
 
+	try:
+		play_full_game_turn_loop(game)
+	except GameOver:
+		print("Game completed normally.")
+
+	return game
+
+
+def play_full_game_turn_loop(game):
 	while True:
 		player = game.current_player
 

--- a/tests/full_game.py
+++ b/tests/full_game.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python
 import sys; sys.path.append("..")
+import logging
 from fireplace import cards
 from fireplace.utils import play_full_game
 
 
 def test_full_game():
-	play_full_game()
+	return play_full_game(False)
 
 
 def main():
+	turns = []
+	runtime = []
+
+	logging.disable(logging.CRITICAL)
+
 	cards.db.initialize()
 	if len(sys.argv) > 1:
 		numgames = sys.argv[1]
 		if not numgames.isdigit():
 			sys.stderr.write("Usage: %s [NUMGAMES]\n" % (sys.argv[0]))
 			exit(1)
-		for i in range(int(numgames)):
-			test_full_game()
 	else:
-		test_full_game()
+		numgames = 1
 
+	for i in range(int(numgames)):
+		game = test_full_game()
+		turns.append(game.turn)
+		runtime.append(game.runtime)
+
+	avg_runtime_per_game = sum(runtime) / len(runtime)
+	avg_turns_per_game = sum(turns) / len(turns)
+	avg_games_per_second = int(numgames) / sum(runtime)
+	avg_turns_per_second = sum(turns) / sum(runtime)
+
+	print("Average runtime over " + str(numgames) + " games: %.2f sec" % avg_runtime_per_game)
+	print("Average turns per game: %.2f" % avg_turns_per_game)
+	print("Average games per second: %.2f" % avg_games_per_second)
+	print("Average turns per second: %.2f" % avg_turns_per_second)
 
 if __name__ == "__main__":
 	main()

--- a/tests/full_game.py
+++ b/tests/full_game.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
 import sys; sys.path.append("..")
 from fireplace import cards
-from fireplace.exceptions import GameOver
 from fireplace.utils import play_full_game
 
 
 def test_full_game():
-	try:
-		play_full_game()
-	except GameOver:
-		print("Game completed normally.")
+	play_full_game()
 
 
 def main():


### PR DESCRIPTION
Show games per second, turns per second, runtime per game and runtime per turn. Output logging is disabled to avoid benchmark interference from console or file output.

Requires #359, #360 and #361 to work.
