### PR TITLE
Implement most Rogue, Warlock, and neutral cards

### DIFF
--- a/fireplace/cards/wog/__init__.py
+++ b/fireplace/cards/wog/__init__.py
@@ -11,3 +11,4 @@ from .neutral_common import *
 from .neutral_rare import *
 from .neutral_epic import *
 from .neutral_legendary import *
+from .toxins import *

--- a/fireplace/cards/wog/neutral_common.py
+++ b/fireplace/cards/wog/neutral_common.py
@@ -19,3 +19,8 @@ class OG_158:
 	deathrattle = Buff(RANDOM_FRIENDLY_MINION, "OG_158e")
 
 OG_158e = buff(+1, +1)
+
+
+class OG_323:
+	"Polluted Hoarder"
+	deathrattle = Draw(CONTROLLER)

--- a/fireplace/cards/wog/neutral_common.py
+++ b/fireplace/cards/wog/neutral_common.py
@@ -4,6 +4,13 @@ from ..utils import *
 ##
 # Minions
 
+class OG_150:
+	"Aberrant Berserker"
+	enrage = Refresh(SELF, buff="OG_150e")
+
+OG_150e = buff(atk=2)
+
+
 class OG_151:
 	"Tentacle of N'Zoth"
 	deathrattle = Hit(ALL_MINIONS, 1)
@@ -19,6 +26,18 @@ class OG_158:
 	deathrattle = Buff(RANDOM_FRIENDLY_MINION, "OG_158e")
 
 OG_158e = buff(+1, +1)
+
+
+class OG_249:
+	"Infested Tauren"
+	deathrattle = Summon(CONTROLLER, "OG_249a")
+
+
+class OG_256:
+	"Spawn of N'Zoth"
+	deathrattle = Buff(FRIENDLY_MINIONS, "OG_256e")
+
+OG_256e = buff(+1, +1)
 
 
 class OG_323:

--- a/fireplace/cards/wog/neutral_common.py
+++ b/fireplace/cards/wog/neutral_common.py
@@ -50,6 +50,11 @@ class OG_256:
 OG_256e = buff(+1, +1)
 
 
+class OG_295:
+	"Cult Apothecary"
+	play = Heal(FRIENDLY_HERO, Count(ENEMY_MINIONS) * 2)
+
+
 class OG_323:
 	"Polluted Hoarder"
 	deathrattle = Draw(CONTROLLER)

--- a/fireplace/cards/wog/neutral_common.py
+++ b/fireplace/cards/wog/neutral_common.py
@@ -4,6 +4,16 @@ from ..utils import *
 ##
 # Minions
 
+class OG_138:
+	"Nerubian Prophet"
+	class Hand:
+		events = OWN_TURN_BEGIN.on(Buff(SELF, "OG_138e"))
+
+class OG_138e:
+	events = REMOVED_IN_PLAY
+	tags = {GameTag.COST: -1}
+
+
 class OG_150:
 	"Aberrant Berserker"
 	enrage = Refresh(SELF, buff="OG_150e")

--- a/fireplace/cards/wog/neutral_epic.py
+++ b/fireplace/cards/wog/neutral_epic.py
@@ -4,6 +4,15 @@ from ..utils import *
 ##
 # Minions
 
+class OG_200:
+	"Validated Doomsayer"
+	events = OWN_TURN_BEGIN.on(Buff(SELF, "OG_200e"))
+
+class OG_200e:
+	"Doom Free"
+	atk = SET(7)
+
+
 class OG_271:
 	"Scaled Nightmare"
 	events = OWN_TURN_BEGIN.on(Buff(SELF, "OG_271e"))

--- a/fireplace/cards/wog/neutral_epic.py
+++ b/fireplace/cards/wog/neutral_epic.py
@@ -10,3 +10,15 @@ class OG_271:
 
 class OG_271e:
 	atk = lambda self, i: i * 2
+
+
+class OG_272:
+	"Twilight Summoner"
+	deathrattle = Summon(CONTROLLER, "OG_272t")
+
+
+class OG_337:
+	"Cyclopian Horror"
+	play = Buff(SELF, "OG_337e") * Count(ENEMY_MINIONS)
+
+OG_337e = buff(health=1)

--- a/fireplace/cards/wog/neutral_epic.py
+++ b/fireplace/cards/wog/neutral_epic.py
@@ -26,6 +26,11 @@ class OG_272:
 	deathrattle = Summon(CONTROLLER, "OG_272t")
 
 
+class OG_290:
+	"Ancient Harbinger"
+	events = OWN_TURN_BEGIN.on(ForceDraw(RANDOM(FRIENDLY_DECK + MINION + (COST == 10))))
+
+
 class OG_337:
 	"Cyclopian Horror"
 	play = Buff(SELF, "OG_337e") * Count(ENEMY_MINIONS)

--- a/fireplace/cards/wog/neutral_epic.py
+++ b/fireplace/cards/wog/neutral_epic.py
@@ -4,11 +4,6 @@ from ..utils import *
 ##
 # Minions
 
-class OG_151:
-	"Tentacle of N'Zoth"
-	deathrattle = Hit(ALL_MINIONS, 1)
-
-
 class OG_271:
 	"Scaled Nightmare"
 	events = OWN_TURN_BEGIN.on(Buff(SELF, "OG_271e"))

--- a/fireplace/cards/wog/neutral_legendary.py
+++ b/fireplace/cards/wog/neutral_legendary.py
@@ -4,6 +4,11 @@ from ..utils import *
 ##
 # Minions
 
+class OG_042:
+	"Y'Shaarj, Rage Unbound"
+	events = OWN_TURN_END.on(Summon(CONTROLLER, RANDOM(FRIENDLY_DECK + MINION)))
+
+
 class OG_122:
 	"Mukla, Tyrant of the Vale"
 	play = Give(CONTROLLER, "EX1_014t") * 2

--- a/fireplace/cards/wog/neutral_legendary.py
+++ b/fireplace/cards/wog/neutral_legendary.py
@@ -9,6 +9,11 @@ class OG_122:
 	play = Give(CONTROLLER, "EX1_014t") * 2
 
 
+class OG_317:
+	"Deathwing, Dragonlord"
+	deathrattle = Summon(CONTROLLER, FRIENDLY_HAND + DRAGON)
+
+
 class OG_318:
 	"Hogger, Doom of Elwynn"
 	events = SELF_DAMAGE.on(Summon(CONTROLLER, "OG_318t"))

--- a/fireplace/cards/wog/neutral_legendary.py
+++ b/fireplace/cards/wog/neutral_legendary.py
@@ -3,3 +3,17 @@ from ..utils import *
 
 ##
 # Minions
+
+class OG_122:
+	"Mukla, Tyrant of the Vale"
+	play = Give(CONTROLLER, "EX1_014t") * 2
+
+
+class OG_318:
+	"Hogger, Doom of Elwynn"
+	events = SELF_DAMAGE.on(Summon(CONTROLLER, "OG_318t"))
+
+
+class OG_338:
+	"Nat, the Darkfisher"
+	events = BeginTurn(OPPONENT).on(COINFLIP & Draw(OPPONENT))

--- a/fireplace/cards/wog/neutral_rare.py
+++ b/fireplace/cards/wog/neutral_rare.py
@@ -4,13 +4,8 @@ from ..utils import *
 ##
 # Minions
 
-# Silithid Swarmer
 class OG_034:
+	"Silithid Swarmer"
 	update = (NUM_ATTACKS_THIS_TURN(FRIENDLY_HERO) == 0) & (
 		Refresh(SELF, {GameTag.CANT_ATTACK: True})
 	)
-
-
-# Tentacle of N'Zoth
-class OG_151:
-	deathrattle = Hit(ALL_MINIONS, 1)

--- a/fireplace/cards/wog/neutral_rare.py
+++ b/fireplace/cards/wog/neutral_rare.py
@@ -11,6 +11,16 @@ class OG_034:
 	)
 
 
+class OG_254:
+	"Eater of Secrets"
+	play = (
+		Buff(SELF, "OG_254e") * Count(ENEMY_SECRETS),
+		Destroy(ENEMY_SECRETS)
+	)
+
+OG_254e = buff(+1, +1)
+
+
 class OG_322:
 	"Blackwater Pirate"
 	update = Refresh(FRIENDLY_HAND + WEAPON, {GameTag.COST: -2})

--- a/fireplace/cards/wog/neutral_rare.py
+++ b/fireplace/cards/wog/neutral_rare.py
@@ -9,3 +9,8 @@ class OG_034:
 	update = (NUM_ATTACKS_THIS_TURN(FRIENDLY_HERO) == 0) & (
 		Refresh(SELF, {GameTag.CANT_ATTACK: True})
 	)
+
+
+class OG_322:
+	"Blackwater Pirate"
+	update = Refresh(FRIENDLY_HAND + WEAPON, {GameTag.COST: -2})

--- a/fireplace/cards/wog/neutral_rare.py
+++ b/fireplace/cards/wog/neutral_rare.py
@@ -11,6 +11,16 @@ class OG_034:
 	)
 
 
+class OG_147:
+	"Corrupted Healbot"
+	deathrattle = Heal(ENEMY_HERO, 8)
+
+
+class OG_161:
+	"Corrupted Seer"
+	play = Hit(ALL_MINIONS - MURLOC, 2)
+
+
 class OG_254:
 	"Eater of Secrets"
 	play = (
@@ -19,6 +29,13 @@ class OG_254:
 	)
 
 OG_254e = buff(+1, +1)
+
+
+class OG_320:
+	"Midnight Drake"
+	play = Buff(SELF, "OG_320e") * Count(FRIENDLY_HAND)
+
+OG_320e = buff(atk=1)
 
 
 class OG_322:

--- a/fireplace/cards/wog/rogue.py
+++ b/fireplace/cards/wog/rogue.py
@@ -11,6 +11,11 @@ class OG_070:
 OG_070e = buff(+1, +1)
 
 
+class OG_080:
+	"Xaril, Poisoned Mind"
+	play = deathrattle = Give(CONTROLLER, RandomEntourage())
+
+
 class OG_267:
 	"Southsea Squidface"
 	deathrattle = Buff(FRIENDLY_WEAPON, "OG_267e")

--- a/fireplace/cards/wog/rogue.py
+++ b/fireplace/cards/wog/rogue.py
@@ -18,6 +18,11 @@ class OG_267:
 OG_267e = buff(atk=2)
 
 
+class OG_330:
+	"Undercity Huckster"
+	deathrattle = Give(CONTROLLER, RandomCollectible(card_class=ENEMY_CLASS))
+
+
 ##
 # Spells
 

--- a/fireplace/cards/wog/rogue.py
+++ b/fireplace/cards/wog/rogue.py
@@ -21,6 +21,11 @@ OG_267e = buff(atk=2)
 ##
 # Spells
 
+class OG_072:
+	"Journey Below"
+	play = DISCOVER(RandomCollectible(deathrattle=True))
+
+
 class OG_073:
 	"Thistle Tea"
 	play = Draw(CONTROLLER).then(Give(CONTROLLER, Copy(Draw.CARD)) * 2)

--- a/fireplace/cards/wog/rogue.py
+++ b/fireplace/cards/wog/rogue.py
@@ -4,6 +4,19 @@ from ..utils import *
 ##
 # Minions
 
+class OG_070:
+	"Bladed Cultist"
+	combo = Buff(SELF, "OG_070e")
+
+OG_070e = buff(+1, +1)
+
+
+class OG_267:
+	"Southsea Squidface"
+	deathrattle = Buff(FRIENDLY_WEAPON, "OG_267e")
+
+OG_267e = buff(atk=2)
+
 
 ##
 # Spells
@@ -11,3 +24,8 @@ from ..utils import *
 class OG_073:
 	"Thistle Tea"
 	play = Draw(CONTROLLER).then(Give(CONTROLLER, Copy(Draw.CARD)) * 2)
+
+
+class OG_176:
+	"Shadow Strike"
+	play = Hit(TARGET, 5)

--- a/fireplace/cards/wog/toxins.py
+++ b/fireplace/cards/wog/toxins.py
@@ -1,0 +1,47 @@
+"""
+Xaril's Toxins
+"""
+
+from ..utils import *
+
+
+class OG_080b:
+	"Kingsblood Toxin"
+	play = Draw(CONTROLLER)
+
+
+class OG_080c:
+	"Bloodthistle Toxin"
+	play = Bounce(TARGET), Buff(TARGET, "EX1_144e")
+
+class OG_080ae:
+	tags = {
+		GameTag.CARDNAME: "Bloodthistle",
+		GameTag.CARDTYPE: CardType.ENCHANTMENT,
+		GameTag.COST: -2,
+	}
+	events = REMOVED_IN_PLAY
+
+
+class OG_080d:
+	"Briarthorn Toxin"
+	play = Buff(TARGET, "OG_080ee")
+
+OG_080ee = buff(atk=3)
+
+
+class OG_080e:
+	"Fadeleaf Toxin"
+	play = (
+		Buff(TARGET - STEALTH, "OG_080de"),
+		Stealth(TARGET)
+	)
+
+class OG_080de:
+	"Fadeleaf"
+	events = OWN_TURN_BEGIN.on(Unstealth(OWNER), Destroy(SELF))
+
+
+class OG_080f:
+	"Firebloom Toxin"
+	play = Hit(TARGET, 2)

--- a/fireplace/cards/wog/warlock.py
+++ b/fireplace/cards/wog/warlock.py
@@ -11,3 +11,11 @@ class OG_121:
 class OG_121e:
 	events = OWN_SPELL_PLAY.on(Destroy(SELF))
 	update = Refresh(CONTROLLER, {GameTag.SPELLS_COST_HEALTH: True})
+
+
+##
+# Spells
+
+class OG_116:
+	"Spreading Madness"
+	play = Hit(RANDOM_CHARACTER, 1) * 9

--- a/fireplace/cards/wog/warlock.py
+++ b/fireplace/cards/wog/warlock.py
@@ -4,6 +4,19 @@ from ..utils import *
 ##
 # Minions
 
+class OG_109:
+	"Darkshire Librarian"
+	play = Discard(RANDOM(FRIENDLY_HAND))
+	deathrattle = Draw(CONTROLLER)
+
+
+class OG_113:
+	"Darkshire Councilman"
+	events = Summon(MINION, CONTROLLER).on(Buff(SELF, "OG_113e"))
+
+OG_113e = buff(atk=1)
+
+
 class OG_121:
 	"Cho'gall"
 	play = Buff(CONTROLLER, "OG_121e")
@@ -11,6 +24,11 @@ class OG_121:
 class OG_121e:
 	events = OWN_SPELL_PLAY.on(Destroy(SELF))
 	update = Refresh(CONTROLLER, {GameTag.SPELLS_COST_HEALTH: True})
+
+
+class OG_241:
+	"Possessed Villager"
+	deathrattle = Summon(CONTROLLER, "OG_241a")
 
 
 ##

--- a/fireplace/cards/wog/warlock.py
+++ b/fireplace/cards/wog/warlock.py
@@ -37,3 +37,11 @@ class OG_241:
 class OG_116:
 	"Spreading Madness"
 	play = Hit(RANDOM_CHARACTER, 1) * 9
+
+
+class OG_239:
+	"DOOM!"
+	def play(self):
+		minion_count = len(self.controller.field) + len(self.controller.opponent.field)
+		yield Destroy(ALL_MINIONS)
+		yield Draw(CONTROLLER) * minion_count

--- a/tests/test_league.py
+++ b/tests/test_league.py
@@ -227,7 +227,7 @@ def test_ethereal_conjurer():
 	assert len(game.player1.choice.cards) == 3
 	for card in game.player1.choice.cards:
 		assert card.type == CardType.SPELL
-		# assert card.card_class == CardClass.MAGE  # TODO
+		assert card.card_class == CardClass.MAGE
 
 
 def test_everyfin_is_awesome():

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -195,6 +195,20 @@ def test_doom():
 	assert len(game.player1.hand) == 3
 
 
+def test_eater_of_secrets():
+	game = prepare_game()
+	eater_of_secrets = game.player1.give("OG_254")
+	game.end_turn()
+	game.player2.give("EX1_379").play()
+	game.player2.give("EX1_609").play()
+	game.player2.give("EX1_294").play()
+	game.end_turn()
+	eater_of_secrets.play()
+	assert eater_of_secrets.atk == 5
+	assert eater_of_secrets.health == 7
+	assert not game.player2.secrets
+
+
 def test_feral_rage():
 	game = prepare_game()
 	game.player1.give("OG_047").play(choose="OG_047a")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -503,6 +503,22 @@ def test_undercity_huckster():
 	assert game.player1.hand[0].card_class == game.player2.hero.card_class
 
 
+def test_validated_doomsayer():
+	game = prepare_game()
+	validated_doomsayer = game.player1.give("OG_200")
+	validated_doomsayer.play()
+	assert validated_doomsayer.atk == 0
+	game.end_turn()
+	assert validated_doomsayer.atk == 0
+	game.end_turn()
+	assert validated_doomsayer.atk == 7
+	game.end_turn()
+	game.player2.give("EX1_360").play(target=validated_doomsayer)
+	assert validated_doomsayer.atk == 1
+	game.end_turn()
+	assert validated_doomsayer.atk == 7
+
+
 def test_vilefin_inquisitor():
 	game = prepare_game()
 	vilefin_inquisitor = game.player1.give("OG_006")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -207,6 +207,15 @@ def test_hallazeal_the_ascended():
 	assert hallazeal.dead
 
 
+def test_journey_below():
+	game = prepare_empty_game()
+	journey_below = game.player1.give("OG_072")
+	journey_below.play()
+	assert len(game.player1.choice.cards) == 3
+	for card in game.player1.choice.cards:
+		assert card.has_deathrattle
+
+
 def test_malkorok():
 	game = prepare_game()
 	malkorok = game.player1.give("OG_220")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -155,6 +155,16 @@ def test_demented_frostcaller():
 	game.player1.give(THE_COIN).play()
 
 
+def test_doom():
+	game = prepare_game()
+	game.player1.discard_hand()
+	game.player1.give(WISP).play()
+	game.player1.give(WISP).play()
+	game.player1.give(WISP).play()
+	game.player1.give("OG_239").play()
+	assert len(game.player1.hand) == 3
+
+
 def test_feral_rage():
 	game = prepare_game()
 	game.player1.give("OG_047").play(choose="OG_047a")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -26,6 +26,19 @@ def test_addled_grizzly():
 	assert wisp.atk == wisp.health == 3
 
 
+def test_blackwater_pirate():
+	game = prepare_game()
+	game.player1.give("OG_322").play()
+	reaper = game.player1.give("CS2_112")
+	kobold = game.player1.give(KOBOLD_GEOMANCER)
+	mc = game.player1.give(MIND_CONTROL)
+	assert reaper.cost == 3
+	assert kobold.cost == 2
+	assert mc.cost == 10
+	reaper.play()
+	assert reaper.cost == 5
+
+
 def test_blood_to_ichor():
 	game = prepare_game()
 	shieldbearer = game.player1.give("EX1_405").play()

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -186,6 +186,19 @@ def test_cult_apothecary():
 	assert lightwarden.atk == 3
 
 
+def test_deathwing_dragonlord():
+	game = prepare_game()
+	game.player1.discard_hand()
+	deathwing = game.player1.give("OG_317")
+	ysera = game.player1.give("EX1_572")
+	azure_drake = game.player1.give("EX1_284")
+	wisp = game.player1.give(WISP)
+	deathwing.play()
+	deathwing.destroy()
+	assert game.player1.hand == [wisp]
+	assert game.player1.field == [ysera, azure_drake]
+
+
 def test_demented_frostcaller():
 	game = prepare_game()
 	game.player1.give("OG_085").play()

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -261,6 +261,20 @@ def test_mire_keeper():
 	assert game.player1.max_mana == 10
 
 
+def test_nerubian_prophet():
+	game = prepare_game()
+	nerubian_prophet = game.player1.give("OG_138")
+	assert nerubian_prophet.cost == 6
+	game.end_turn(); game.end_turn()
+	
+	assert nerubian_prophet.cost == 5
+	game.end_turn(); game.end_turn()
+	
+	assert nerubian_prophet.cost == 4
+	nerubian_prophet.play()
+	assert nerubian_prophet.cost == 6
+
+
 def test_primal_fusion():
 	game = prepare_game(CardClass.SHAMAN, CardClass.SHAMAN)
 	fusion0 = game.player1.give("OG_023")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -12,7 +12,7 @@ def test_a_light_in_the_darkness():
 		card.clear_buffs()
 		basehp = card.health
 		assert buffhp == basehp + 1
-		# TODO: put a test for card class here, once it's implemented
+		assert not hasattr(card, "card_class") or card.card_class == CardClass.PALADIN
 
 
 def test_addled_grizzly():

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -140,6 +140,23 @@ def test_chogall_cannot_pay_health():
 	assert not fireball.is_playable()
 
 
+def test_cult_apothecary():
+	game = prepare_game()
+	cult_apothecary = game.player1.give("OG_295")
+	game.end_turn()
+	game.player2.give(WISP).play()
+	game.player2.give(WISP).play()
+	game.player2.give(WISP).play()
+	game.player2.give(WISP).play()
+	game.end_turn()
+	game.player1.hero.set_current_health(10)
+	lightwarden = game.player1.give("EX1_001")
+	lightwarden.play()
+	cult_apothecary.play()
+	assert game.player1.hero.health == 10 + 8
+	assert lightwarden.atk == 3
+
+
 def test_demented_frostcaller():
 	game = prepare_game()
 	game.player1.give("OG_085").play()

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -238,6 +238,17 @@ def test_eater_of_secrets():
 	assert not game.player2.secrets
 
 
+def test_evolved_kobold():
+	game = prepare_game()
+	deathlord = game.player1.give("FP1_009")
+	deathlord.play()
+	game.player1.give(MOONFIRE).play(target=deathlord)
+	assert deathlord.health == 7
+	game.player1.give("OG_082").play()
+	game.player1.give(MOONFIRE).play(target=deathlord)
+	assert deathlord.health == 4
+
+
 def test_feral_rage():
 	game = prepare_game()
 	game.player1.give("OG_047").play(choose="OG_047a")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -426,6 +426,15 @@ def test_thistle_tea():
 	assert game.player1.hand[0] == game.player1.hand[1] == game.player1.hand[2]
 
 
+def test_undercity_huckster():
+	game = prepare_empty_game()
+	undercity_huckster = game.player1.give("OG_330")
+	undercity_huckster.play()
+	arcane_shot = game.player1.give("DS1_185")
+	arcane_shot.play(target=undercity_huckster)
+	assert game.player1.hand[0].card_class == game.player2.hero.card_class
+
+
 def test_vilefin_inquisitor():
 	game = prepare_game()
 	vilefin_inquisitor = game.player1.give("OG_006")

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -568,3 +568,20 @@ def test_wisps_of_the_old_gods():
 	for wisp in game.player1.field:
 		assert wisp.atk ==  wisp.health == 3
 		assert wisp.id == "OG_195c"
+
+
+def test_yshaarj_rage_unbound():
+	game = prepare_empty_game()
+	yshaarj = game.player1.give("OG_042")
+	wisp = game.player1.give(WISP)
+	wisp.shuffle_into_deck()
+	moonfire = game.player1.give(MOONFIRE)
+	moonfire.shuffle_into_deck()
+	yshaarj.play()
+	game.end_turn()
+	assert game.player1.field == [yshaarj, wisp]
+	assert game.player1.deck == [moonfire]
+	game.end_turn(); game.end_turn()
+
+	assert game.player1.field == [yshaarj, wisp]
+	assert len(game.player1.deck) == 0

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -26,6 +26,22 @@ def test_addled_grizzly():
 	assert wisp.atk == wisp.health == 3
 
 
+def test_ancient_harbinger():
+	game = prepare_empty_game()
+	game.player1.give(WISP).shuffle_into_deck()
+	game.player1.give(IMP).shuffle_into_deck()
+	game.player1.give(GOLDSHIRE_FOOTMAN).shuffle_into_deck()
+	game.player1.give(MIND_CONTROL).shuffle_into_deck()
+	game.player1.give("EX1_279").shuffle_into_deck()
+	game.player1.give("NEW1_030").shuffle_into_deck()
+	game.player1.give("OG_290").play()
+	game.end_turn(); game.end_turn()
+
+	assert game.player1.hand[0].cost == 10
+	assert game.player1.hand[0].type == CardType.MINION
+	assert len(game.player1.hand) == 2
+
+
 def test_blackwater_pirate():
 	game = prepare_game()
 	game.player1.give("OG_322").play()


### PR DESCRIPTION
Cards implemented:
* Rogue: Bladed Cultist, Southsea Squidface, Shadow Strike, Journey Below, Undercity Huckster, and "Xaril, Poisoned Mind" + toxins
* Warlock: Darkshire Librarian, Darkshire Councilman, Possessed Villager, Spreading Madness, and DOOM!
* Neutral commons: Aberrant Berserker, Infested Tauren, Spawn of N'Zoth, Polluted Hoarder, Cult Apothecary and Nerubian Prophet
* Neutral rares: Blackwater Pirate, Eater of Secrets, Corrupted Healbot, Corrupted Seer, and Midnight Drake
* Neutral epics: Twilight Summoner, Cyclopian Horror, Validated Doomsayer, and Ancient Harbinger
* Neutral legendaries: "Mukla, Tyrant of the Vale", "Hogger, Doom of Elwynn", "Nat, the Darkfisher", and "Deathwing, Dragonlord"

Tests implemented for:
* Rogue: Journey Below, Undercity Huckster, and "Xaril, Poisoned Mind"
* Warlock: DOOM!
* Neutral commons: Cult Apothecary and Nerubian Prophet
* Neutral rares: Blackwater Pirate and Eater of Secrets
* Neutral epics: Validated Doomsayer and Ancient Harbinger
* Neutral legendaries: "Deathwing, Dragonlord"