### PR TITLE
Fix unprocessed updates could be put in a block

### DIFF
--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -39,6 +39,9 @@ class KettleManager:
 
 	def action_start(self, type, source, index, target):
 		DEBUG("Beginning new action %r (%r, %r, %r)", type, source, index, target)
+		# prevent unprocessed updates appearing inside the block
+		# this may happen if queued tag changes are outside of blocks
+		self.refresh_full_state()
 		packet = {
 			"SubType": type,
 			"EntityID": source.entity_id,


### PR DESCRIPTION
New turns and such could be incorrectly nested in the action block for the first thing the player does on the turn. This breaks the client horribly.
