### PR TITLE
Fix incorrect PLAY and SECRET zone positions

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -588,7 +588,7 @@ class Minion(Character):
 	def adjacent_minions(self):
 		assert self.zone is Zone.PLAY, self.zone
 		ret = CardList()
-		index = self.zone_position
+		index = self.zone_position - 1
 		left = self.controller.field[:index]
 		right = self.controller.field[index + 1:]
 		if left:
@@ -626,7 +626,7 @@ class Minion(Character):
 	@property
 	def zone_position(self):
 		if self.zone == Zone.PLAY:
-			return self.controller.field.index(self)
+			return self.controller.field.index(self) + 1
 		return super().zone_position
 
 	def _set_zone(self, value):
@@ -703,7 +703,7 @@ class Secret(Spell):
 	@property
 	def zone_position(self):
 		if self.zone == Zone.SECRET:
-			return self.controller.secrets.index(self)
+			return self.controller.secrets.index(self) + 1
 		return super().zone_position
 
 	def _set_zone(self, value):

--- a/fireplace/dsl/selector.py
+++ b/fireplace/dsl/selector.py
@@ -263,7 +263,7 @@ class BoardPositionSelector(Selector):
 		for e in self.child.eval(entities, source):
 			if getattr(e, "zone", None) == Zone.PLAY:
 				field = e.controller.field
-				position = e.zone_position
+				position = e.zone_position - 1
 				if self.direction == self.Direction.RIGHT:
 					# Swap the list, reverse the position
 					field = list(reversed(field))


### PR DESCRIPTION
The first minion played was at ZONE_POSITION = 0, which means kettle doesn't pick it up as a tag change. This is fine for normal minions but for hero power-summoned minions, they fail to materialize and the game hangs.
