### PR TITLE
Wrap hero power action in a PLAY block

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from inspect import isclass
-from hearthstone.enums import CardType, CardClass, Mulligan, PlayState, Step, Zone
+from hearthstone.enums import BlockType, CardType, CardClass, Mulligan, PlayState, Step, Zone
 from .dsl import LazyNum, LazyValue, Selector
 from .entity import Entity
 from .logging import log
@@ -456,7 +456,9 @@ class Activate(GameAction):
 		self.broadcast(source, EventListener.ON, player, heropower, target)
 
 		actions = heropower.get_actions("activate")
+		source.game.action_start(BlockType.PLAY, heropower, 0, target)
 		source.game.main_power(heropower, actions, target)
+		source.game.action_end(BlockType.PLAY, heropower)
 
 		for minion in player.field.filter(has_inspire=True):
 			actions = minion.get_actions("inspire")


### PR DESCRIPTION
Hero powers that summon minions (shaman, paladin) fail to execute and hang the game if not wrapped in a PLAY block.
