### PR TITLE
Fix use of parent_card

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -206,8 +206,7 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 			# Create the "Choose One" subcards
 			del self.choose_cards[:]
 			for id in self.data.choose_cards:
-				card = self.controller.card(id)
-				card.parent_card = self
+				card = self.controller.card(id, source=self, parent=self)
 				self.choose_cards.append(card)
 
 	def destroy(self):

--- a/fireplace/managers.py
+++ b/fireplace/managers.py
@@ -169,6 +169,7 @@ CARD_ATTRIBUTE_MAP = {
 	GameTag.NUM_TURNS_IN_PLAY: "turns_in_play",
 	GameTag.TAG_ONE_TURN_EFFECT: "one_turn_effect",
 	GameTag.OVERLOAD: "overload",
+	GameTag.PARENT_CARD: "parent_card",
 	GameTag.POISONOUS: "poisonous",
 	GameTag.POWERED_UP: "powered_up",
 	GameTag.RARITY: "rarity",

--- a/fireplace/player.py
+++ b/fireplace/player.py
@@ -137,7 +137,7 @@ class Player(Entity, TargetableByAuras):
 	def minion_slots(self):
 		return max(0, self.game.MAX_MINIONS_ON_FIELD - len(self.field))
 
-	def card(self, id, source=None, zone=Zone.SETASIDE):
+	def card(self, id, source=None, parent=None, zone=Zone.SETASIDE):
 		card = Card(id)
 		card.controller = self
 		card.zone = zone
@@ -145,6 +145,8 @@ class Player(Entity, TargetableByAuras):
 		self.game.play_counter += 1
 		if source is not None:
 			card.creator = source
+		if parent is not None:
+			card.parent_card = parent
 		self.game.manager.new_entity(card)
 		return card
 


### PR DESCRIPTION
PARENT_CARD must be sent to Hearthstone at the time the card is created otherwise the choice cards fail to show when playing a 'Choose One'-style card.

In addition PARENT_CARD was not picked up by managers.py.
