### PR TITLE
Fix entity choice cards end action block before selection

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from inspect import isclass
-from hearthstone.enums import CardType, CardClass, Mulligan, PlayState, Step, Zone
+from hearthstone.enums import BlockType, CardType, CardClass, Mulligan, PlayState, Step, Zone
 from .dsl import LazyNum, LazyValue, Selector
 from .entity import Entity
 from .logging import log
@@ -351,6 +351,9 @@ class GenericChoice(GameAction):
 			else:
 				_card.discard()
 		self.player.choice = None
+
+		if card.must_choose_entity:
+			self.game.action_end(BlockType.PLAY, card.controller)
 
 
 class MulliganChoice(GameAction):

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -172,6 +172,14 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 		return bool(self.choose_cards)
 
 	@property
+	def must_choose_entity(self) -> bool:
+		"""
+		Returns True if the card requires user input to choose an entity before it resolves
+		"""
+		play_action = self.get_actions_type("play")
+		return isinstance(play_action, actions.GenericChoice) or isinstance(play_action, actions.Discover)
+
+	@property
 	def powered_up(self):
 		"""
 		Returns True whether the card is "powered up".

--- a/fireplace/entity.py
+++ b/fireplace/entity.py
@@ -48,6 +48,10 @@ class BaseEntity(object):
 			actions = actions(self)
 		return actions
 
+	def get_actions_type(self, name):
+		actions = getattr(self.data.scripts, name)
+		return actions
+
 	def trigger_event(self, source, event, args):
 		"""
 		Trigger an event on the Entity

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -125,7 +125,12 @@ class BaseGame(Entity):
 		type = BlockType.PLAY
 		player = card.controller
 		actions = [Play(card, target, index, choose)]
-		return self.action_block(player, actions, type, index, target)
+
+		if card.must_choose_entity:
+			self.action_start(type, player, index, None)
+			return self.queue_actions(player, actions)
+		else:
+			return self.action_block(player, actions, type, index, target)
 
 	def process_deaths(self):
 		type = BlockType.DEATHS


### PR DESCRIPTION
This is the first of a two-part fix for cards that require user interaction before their execution can complete.

Playing a card with a GenericChoice or Discover play script will now leave the action block open. Selecting cards with .choose(...) will close the block.

There are many ways to solve this problem but this one requires no code changes whatsoever, and no special calls by the user for these types of cards.

Since a choice is waiting, no other cards can be played during the choice so the action blocks will not get incorrectly nested.

The cards still don't show up in Hearthstone but the packet ordering is much better now. The second part of the fix will complete this.
