### PR TITLE
Fix source of PLAY action blocks

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from inspect import isclass
-from hearthstone.enums import CardType, CardClass, Mulligan, PlayState, Step, Zone
+from hearthstone.enums import BlockType, CardType, CardClass, Mulligan, PlayState, Step, Zone
 from .dsl import LazyNum, LazyValue, Selector
 from .entity import Entity
 from .logging import log
@@ -351,6 +351,9 @@ class GenericChoice(GameAction):
 			else:
 				_card.discard()
 		self.player.choice = None
+
+		if card.must_choose_entity:
+			self.game.action_end(BlockType.PLAY, card.controller)
 
 
 class MulliganChoice(GameAction):

--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -353,7 +353,7 @@ class GenericChoice(GameAction):
 		self.player.choice = None
 
 		if card.must_choose_entity:
-			self.game.action_end(BlockType.PLAY, card.controller)
+			self.game.action_end(BlockType.PLAY, card)
 
 
 class MulliganChoice(GameAction):

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -172,6 +172,14 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 		return bool(self.choose_cards)
 
 	@property
+	def must_choose_entity(self) -> bool:
+		"""
+		Returns True if the card requires user input to choose an entity before it resolves
+		"""
+		play_action = self.get_actions_type("play")
+		return isinstance(play_action, actions.GenericChoice) or isinstance(play_action, actions.Discover)
+
+	@property
 	def powered_up(self):
 		"""
 		Returns True whether the card is "powered up".

--- a/fireplace/entity.py
+++ b/fireplace/entity.py
@@ -48,6 +48,10 @@ class BaseEntity(object):
 			actions = actions(self)
 		return actions
 
+	def get_actions_type(self, name):
+		actions = getattr(self.data.scripts, name)
+		return actions
+
 	def trigger_event(self, source, event, args):
 		"""
 		Trigger an event on the Entity

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -125,7 +125,12 @@ class BaseGame(Entity):
 		type = BlockType.PLAY
 		player = card.controller
 		actions = [Play(card, target, index, choose)]
-		return self.action_block(player, actions, type, index, target)
+
+		if card.must_choose_entity:
+			self.action_start(type, player, index, None)
+			return self.queue_actions(player, actions)
+		else:
+			return self.action_block(player, actions, type, index, target)
 
 	def process_deaths(self):
 		type = BlockType.DEATHS

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -99,13 +99,16 @@ class BaseGame(Entity):
 			self.refresh_auras()
 			self.process_deaths()
 
-	def action_block(self, source, actions, type, index=-1, target=None, event_args=None):
-		self.action_start(type, source, index, target)
+	def action_block(self, source, actions, type, index=-1, target=None, event_args=None, card_source=None):
+		action_source = queue_source = source
+		if card_source is not None:
+			action_source = card_source
+		self.action_start(type, action_source, index, target)
 		if actions:
-			ret = self.queue_actions(source, actions, event_args)
+			ret = self.queue_actions(queue_source, actions, event_args)
 		else:
 			ret = []
-		self.action_end(type, source)
+		self.action_end(type, action_source)
 		return ret
 
 	def attack(self, source, target):
@@ -127,10 +130,10 @@ class BaseGame(Entity):
 		actions = [Play(card, target, index, choose)]
 
 		if card.must_choose_entity:
-			self.action_start(type, player, index, None)
+			self.action_start(type, card, index, None)
 			return self.queue_actions(player, actions)
 		else:
-			return self.action_block(player, actions, type, index, target)
+			return self.action_block(player, actions, type, index, target, card_source=card)
 
 	def process_deaths(self):
 		type = BlockType.DEATHS


### PR DESCRIPTION
Actions where a card is played from hand must use the card's entity ID as the source in action blocks, not the player's entity ID. This fixes the in-game vertical left-hand side logging in Hearthstone.

Requires #390 