### PR TITLE
Send ShowEntity list when playing entity choice card

### DIFF
--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -147,6 +147,8 @@ class KettleManager:
 			"Source": choice.source.entity_id,
 			"PlayerId": 1,
 		}
+		for show_choice in choice.cards:
+			self.queued_data.append(self.show_entity(show_choice))
 		payload = {"Type": "EntityChoices", "EntityChoices": self.choices}
 		self.queued_data.append(payload)
 
@@ -251,6 +253,16 @@ class KettleManager:
 	def full_entity(self, entity):
 		return {
 			"Type": "FullEntity",
+			"FullEntity": {
+				"CardID": entity.id,
+				"EntityID": entity.entity_id,
+				"Tags": self.game_state[entity.entity_id],
+			}
+		}
+
+	def show_entity(self, entity):
+		return {
+			"Type": "ShowEntity",
 			"FullEntity": {
 				"CardID": entity.id,
 				"EntityID": entity.entity_id,


### PR DESCRIPTION
The client expects to be told to show entities on the screen by the server when playing a choice-giving card, before EntityChoices is sent. This in combination with the already-merged stove PR provides the necessary data to the client.
