### PR TITLE
Kettle: don't send internal fireplace tags

### DIFF
--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -214,6 +214,8 @@ class KettleManager:
 		self.game.current_player.choice.choose(*entities)
 
 	def tag_change(self, entity, tag, value):
+		if tag < 0:
+			return
 		DEBUG("Queueing a tag change for entity %r: %r -> %r", entity, tag, value)
 		payload = {
 			"Type": "TagChange",


### PR DESCRIPTION
The internal tags (-10 to -13) were being sent over the wire. This is bad.
