### PR TITLE
Make entity choice cards work in the client

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from inspect import isclass
-from hearthstone.enums import CardType, CardClass, Mulligan, PlayState, Step, Zone
+from hearthstone.enums import BlockType, CardType, CardClass, Mulligan, PlayState, Step, Zone
 from .dsl import LazyNum, LazyValue, Selector
 from .entity import Entity
 from .logging import log
@@ -351,6 +351,9 @@ class GenericChoice(GameAction):
 			else:
 				_card.discard()
 		self.player.choice = None
+
+		if card.must_choose_entity:
+			card.game.action_end(BlockType.PLAY, card.controller)
 
 
 class MulliganChoice(GameAction):

--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -715,20 +715,21 @@ class Battlecry(TargetedAction):
 
 
 class BattlecryContinue(Battlecry):
+	"""
+	Continue Battlecry on card targets. INTERNAL USE ONLY
+	"""
 	def do(self, source, card, target):
 		player = card.controller
 
-		if player.extra_battlecries and card.has_battlecry:
-			if card.has_combo and player.combo:
-				actions = card.get_actions("combo")
-			else:
-				actions = card.get_actions("play")
-			source.game.main_power(source, actions, target)
-
 		if card.overload:
 			source.game.queue_actions(card, [Overload(player, card.overload)])
-
 		source.game.action_end(BlockType.POWER, source)
+
+		if player.extra_battlecries and card.has_battlecry and not player.is_doing_extra_battlecries:
+			player.is_doing_extra_battlecries = True
+			source.game.queue_actions(source, [Battlecry(card, target)])
+		else:
+			player.is_doing_extra_battlecries = False
 
 
 class Destroy(TargetedAction):

--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -172,6 +172,17 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 		return bool(self.choose_cards)
 
 	@property
+	def must_choose_entity(self) -> bool:
+		"""
+		Returns True if the card requires user input to choose an entity before it resolves
+		"""
+		# get first play action
+		play_action = self.get_actions_type("play")
+		if isinstance(play_action, tuple):
+			play_action = play_action[0]
+		return isinstance(play_action, actions.GenericChoice) or isinstance(play_action, actions.Discover)
+
+	@property
 	def powered_up(self):
 		"""
 		Returns True whether the card is "powered up".

--- a/fireplace/entity.py
+++ b/fireplace/entity.py
@@ -48,6 +48,10 @@ class BaseEntity(object):
 			actions = actions(self)
 		return actions
 
+	def get_actions_type(self, name):
+		actions = getattr(self.data.scripts, name)
+		return actions
+
 	def trigger_event(self, source, event, args):
 		"""
 		Trigger an event on the Entity

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -125,7 +125,12 @@ class BaseGame(Entity):
 		type = BlockType.PLAY
 		player = card.controller
 		actions = [Play(card, target, index, choose)]
-		return self.action_block(player, actions, type, index, target)
+
+		if card.must_choose_entity:
+			self.action_start(type, player, index, None)
+			return self.queue_actions(player, actions)
+		else:
+			return self.action_block(player, actions, type, index, target)
 
 	def process_deaths(self):
 		type = BlockType.DEATHS

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -99,13 +99,16 @@ class BaseGame(Entity):
 			self.refresh_auras()
 			self.process_deaths()
 
-	def action_block(self, source, actions, type, index=-1, target=None, event_args=None):
-		self.action_start(type, source, index, target)
+	def action_block(self, source, actions, type, index=-1, target=None, event_args=None, card_source=None):
+		action_source = queue_source = source
+		if card_source is not None:
+			action_source = card_source
+		self.action_start(type, action_source, index, target)
 		if actions:
-			ret = self.queue_actions(source, actions, event_args)
+			ret = self.queue_actions(queue_source, actions, event_args)
 		else:
 			ret = []
-		self.action_end(type, source)
+		self.action_end(type, action_source)
 		return ret
 
 	def attack(self, source, target):
@@ -127,10 +130,10 @@ class BaseGame(Entity):
 		actions = [Play(card, target, index, choose)]
 
 		if card.must_choose_entity:
-			self.action_start(type, player, index, None)
+			self.action_start(type, card, index, None)
 			return self.queue_actions(player, actions)
 		else:
-			return self.action_block(player, actions, type, index, target)
+			return self.action_block(player, actions, type, index, target, card_source=card)
 
 	def process_deaths(self):
 		type = BlockType.DEATHS

--- a/fireplace/managers.py
+++ b/fireplace/managers.py
@@ -1,9 +1,11 @@
 from hearthstone.enums import GameTag
 from . import enums
+from . import logging
 
 
 class Manager(object):
 	def __init__(self, obj):
+		self.logger = logging.log
 		self.obj = obj
 		self.observers = []
 
@@ -56,24 +58,29 @@ class GameManager(Manager):
 		obj.entity_id = self.counter
 
 	def action_start(self, type, source, index, target):
+		self.logger.debug("Beginning new action %r (%r, %r, %r)", type, source, index, target)
 		for observer in self.observers:
 			observer.action_start(type, source, index, target)
 
 	def action_end(self, type, source):
+		self.logger.debug("Ending action %r", type)
 		for observer in self.observers:
 			observer.action_end(type, source)
 
 	def new_entity(self, entity):
 		self.counter += 1
 		entity.entity_id = self.counter
+		self.logger.debug("Creating entity %r", entity)
 		for observer in self.observers:
 			observer.new_entity(entity)
 
 	def start_game(self):
+		self.logger.debug("Starting new game")
 		for observer in self.observers:
 			observer.start_game()
 
 	def step(self, step, next_step=None):
+		self.logger.debug("Game.STEP changes to %r (next step is %r)", step, next_step)
 		for observer in self.observers:
 			observer.game_step(step, next_step)
 		self.obj.step = step

--- a/fireplace/player.py
+++ b/fireplace/player.py
@@ -50,6 +50,7 @@ class Player(Entity, TargetableByAuras):
 		self.overload_locked = 0
 		self._max_mana = 0
 		self._start_hand_size = 3
+		self.is_doing_extra_battlecries = False
 		self.playstate = PlayState.INVALID
 		self.temp_mana = 0
 		self.timeout = 75

--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -141,6 +141,9 @@ class KettleManager:
 			"Source": choice.source.entity_id,
 			"PlayerId": 1,
 		}
+		for show_choice in choice.cards:
+			self.refresh_state(show_choice.entity_id)
+			self.queued_data.append(self.show_entity(show_choice))
 		payload = {"Type": "EntityChoices", "EntityChoices": self.choices}
 		self.queued_data.append(payload)
 

--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -38,7 +38,6 @@ class KettleManager:
 		self.queued_data = []
 
 	def action_start(self, type, source, index, target):
-		DEBUG("Beginning new action %r (%r, %r, %r)", type, source, index, target)
 		packet = {
 			"SubType": type,
 			"EntityID": source.entity_id,
@@ -49,13 +48,11 @@ class KettleManager:
 		self.queued_data.append(payload)
 
 	def action_end(self, type, source):
-		DEBUG("Ending action %r", type)
 		self.refresh_full_state()
 		payload = {"Type": "ActionEnd"}
 		self.queued_data.append(payload)
 
 	def game_step(self, step, next_step):
-		DEBUG("Game.STEP changes to %r (next step is %r)", step, next_step)
 		self.refresh_full_state()
 
 	def add_to_state(self, entity):

--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -214,6 +214,7 @@ class KettleManager:
 			# assert entity_id in self.choices["Entities"]
 			entities.append(self.get_entity(entity_id))
 		self.game.current_player.choice.choose(*entities)
+		self.options_sent = False
 
 	def tag_change(self, entity, tag, value):
 		DEBUG("Queueing a tag change for entity %r: %r -> %r", entity, tag, value)

--- a/kettle/kettle.py
+++ b/kettle/kettle.py
@@ -67,33 +67,35 @@ class KettleManager:
 		# Don't have a way of getting entities by ID in fireplace yet
 		state[GameTag.ENTITY_ID] = entity
 
-	def refresh_tag(self, entity, tag):
+	def refresh_tag(self, entity, tag, queue=True):
 		state = self.game_state[entity.entity_id]
 		value = entity.tags.get(tag, 0)
 		if isinstance(value, str):
 			return
 		if not value:
 			if state.get(tag, 0):
-				self.tag_change(entity, tag, 0)
+				if queue:
+					self.tag_change(entity, tag, 0)
 				del state[tag]
 		elif int(value) != state.get(tag, 0):
-			self.tag_change(entity, tag, int(value))
+			if queue:
+				self.tag_change(entity, tag, int(value))
 			state[tag] = int(value)
 
-	def refresh_full_state(self):
+	def refresh_full_state(self, queue=True):
 		if self.game.step < Step.BEGIN_MULLIGAN:
 			return
 		for entity in self.game:
 			if entity.entity_id in self.game_state:
 				self.refresh_state(entity.entity_id)
 
-	def refresh_state(self, entity_id):
+	def refresh_state(self, entity_id, queue=True):
 		assert entity_id in self.game_state
 		entity = self.game_state[entity_id][GameTag.ENTITY_ID]
 		state = self.game_state[entity.entity_id]
 
 		for tag in entity.tags:
-			self.refresh_tag(entity, tag)
+			self.refresh_tag(entity, tag, queue)
 
 	def get_options(self, entity):
 		ret = []
@@ -142,7 +144,7 @@ class KettleManager:
 			"PlayerId": 1,
 		}
 		for show_choice in choice.cards:
-			self.refresh_state(show_choice.entity_id)
+			self.refresh_state(show_choice.entity_id, False)
 			self.queued_data.append(self.show_entity(show_choice))
 		payload = {"Type": "EntityChoices", "EntityChoices": self.choices}
 		self.queued_data.append(payload)

--- a/tests/test_brann_bronzebeard.py
+++ b/tests/test_brann_bronzebeard.py
@@ -56,3 +56,20 @@ def test_brann_youthful_brewmaster():
 	brewmaster = game.player1.give("EX1_049")
 	brewmaster.play(target=brann)
 	assert brann in game.player1.hand
+
+
+def test_brann_discover():
+	game, brann = _prepare_game()
+	tomb_spider = game.player1.give("LOE_047")
+	assert not game.player1.choice
+	tomb_spider.play()
+	assert game.player1.choice
+	assert not game.player1.is_doing_extra_battlecries
+	choice = random.choice(game.player1.choice.cards)
+	game.player1.choice.choose(choice)
+	assert game.player1.choice
+	assert game.player1.is_doing_extra_battlecries
+	choice = random.choice(game.player1.choice.cards)
+	game.player1.choice.choose(choice)
+	assert not game.player1.choice
+	assert not game.player1.is_doing_extra_battlecries


### PR DESCRIPTION
By entity choice cards I mean any card such as a Discover card or Tracking which requires user input during the Battlecry action. Currently, the packet flow is all wrong and causes the game to hang, waiting for you to choose entities that can't be seen.

**Current flow**: Start PLAY -> Start POWER -> End POWER -> End PLAY -> Generate entities -> Wait for player choice

**Correct flow**: Start PLAY -> Start POWER -> Generate entities -> Display entities -> Wait for player choice -> End POWER -> End PLAY

In the event of Brann Bronzebeard, an extra POWER block occurs with the same flow after the first one, inside the PLAY block.

This is quite the problem to solve but I have managed to do it without a tick-based loop. This may also fix the issue with Eye of Orsis (LOEA16_13) noted in #329 (or at least go some way towards it), but I cannot confirm that.

To solve the issue, I have split Battlecry up into two actions: Battlecry and BattlecryContinue. The latter only for internal use (wasn't sure what naming convention you wanted for that). This allows you to have open-ended PLAY and POWER blocks that relinquish control to the caller so that user interaction can occur. For cards with no additional user interaction, the end of Battlecry queues BattlecryContinue immediately. For cards with additional user interaction, the end of Battlecry returns, and when the user calls `....choiice.choose(...)`, BattlecryContinue is queued.

I'll walk through what these commits do individually:

4c1c3f4 adds the Card.must_choose_entity property which inspects the card's actions to see if it requires user interaction, and uses this to leave the PLAY block open-ended if so. Note that there is a design issue with the DSL: most play actions are class instances, but those which are functions run immediately on fetch. This causes Bouncing Blade to go into an infinite loop. To get rid of the new get_actions_type function, I recommend in the future (in the FUTURE!), making get_actions wrap functions into a class instance generated on the fly so that execution can be deferred.

e2f82e4 - PLAY action blocks must use the card's entity ID as the source, not the player, where a card entity ID is available. This commit fixes that.

74ad8e4 is very simple and just adds action block logging to managers.py, moving some lines from kettle.py where appropriate

79bf008 simply ensures that the state sent by Kettle down the wire is up to date for the client before queueing a packet that will force the client to wait for entity choices. This ensure the client has received the information it needs to display the cards to be selected from in advance.

5ef1ca0 prevents kettle from sending tag changes for entities which are about to have their full state transmitted anyway - purely a protocol fix

a0224e6 fixes an issue which caused kettle to hang when the user makes an entity choice, because it did not register that the user had responded

55a036c break up the Battlecry action into two portions so that POWER blocks can also be open-ended. At this point, choice interactions work correctly in the client

7e9da41 ensures that if Brann Bronzebeard is active when a card requiring entity choices is played, that the second POWER block will run correctly. To avoid infinite reccursion we add a `is_doing_extra_battlecries` property to Player. In BattlecryContinue, if the player has extra battlecries active (from Brann or any other source), a new Battlecry action will be queued with the same parameters, causing new cards to be discovered etc. A little bit of re-ordering is needed to make sure everything runs in the correct order in all cases. This commit also adds the `test_brann_discover` test which tests `is_doing_extra_battlecries` and `choice` are true and false at the right times.

Tested with py.test and Hearthstone 5.0.0.13030.
