### PR TITLE
Allow can_pay_cost() and is_playable() to use extra mana

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -234,7 +234,7 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 	def heal(self, target, amount):
 		return self.game.cheat_action(self, [actions.Heal(target, amount)])
 
-	def is_playable(self):
+	def is_playable(self, with_extra=0):
 		if self.controller.choice:
 			return False
 		if not self.controller.current_player:
@@ -242,7 +242,7 @@ class PlayableCard(BaseCard, Entity, TargetableByAuras):
 		zone = self.parent_card.zone if self.parent_card else self.zone
 		if zone != self.playable_zone:
 			return False
-		if not self.controller.can_pay_cost(self):
+		if not self.controller.can_pay_cost(self, with_extra):
 			return False
 		if PlayReq.REQ_TARGET_TO_PLAY in self.requirements:
 			if not self.targets:

--- a/fireplace/player.py
+++ b/fireplace/player.py
@@ -178,13 +178,13 @@ class Player(Entity, TargetableByAuras):
 		for card in self.hand[::-1]:
 			card.discard()
 
-	def can_pay_cost(self, card):
+	def can_pay_cost(self, card, with_extra=0):
 		"""
 		Returns whether the player can pay the resource cost of a card.
 		"""
 		if self.spells_cost_health and card.type == CardType.SPELL:
 			return self.hero.health > card.cost
-		return self.mana >= card.cost
+		return self.mana + with_extra >= card.cost
 
 	def pay_cost(self, source, amount: int) -> int:
 		"""


### PR DESCRIPTION
This is a tweak for AI-friendliness which lets you speculate on whether a card would be playable or if you could pay its mana cost if you had X more mana available (eg. before you decide whether to play The Coin or Innervate).
