### PR TITLE
Fix MAIN_COMBAT post-step

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -221,6 +221,7 @@ class Attack(GameAction):
 		attacker.attack_target = None
 		defender.defending = False
 		attacker.num_attacks += 1
+		source.game.manager.step(source.game.next_step, Step.MAIN_END)
 
 
 class BeginTurn(GameAction):


### PR DESCRIPTION
MAIN_COMBAT did not set the game step back to MAIN_ACTION afterwards. This screws up the Hearthstone client in some scenarios.
