### PR TITLE
Keep track of entities in SETASIDE zone

### DIFF
--- a/fireplace/card.py
+++ b/fireplace/card.py
@@ -86,7 +86,8 @@ class BaseCard(BaseEntity):
 			Zone.HAND: self.controller.hand,
 			Zone.DECK: self.controller.deck,
 			Zone.DISCARD: self.controller.discarded,
-			Zone.GRAVEYARD: self.controller.graveyard
+			Zone.GRAVEYARD: self.controller.graveyard,
+			Zone.SETASIDE: self.game.setaside,
 		}
 		if caches.get(old) is not None:
 			caches[old].remove(self)

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -29,13 +29,14 @@ class BaseGame(Entity):
 		self.current_player = None
 		self.tick = 0
 		self.active_aura_buffs = CardList()
+		self.setaside = CardList()
 		self._action_stack = 0
 
 	def __repr__(self):
 		return "%s(players=%r)" % (self.__class__.__name__, self.players)
 
 	def __iter__(self):
-		return chain(self.entities, self.hands, self.decks, self.graveyard, self.discarded)
+		return chain(self.entities, self.hands, self.decks, self.graveyard, self.discarded, self.setaside)
 
 	@property
 	def game(self):


### PR DESCRIPTION
Without this, tag changes for cards going to SETASIDE (or the fact they go to SETASIDE at all) never get tracked when updating game state from Kettle, so cards like Polymorph or anything that uses Morph or moves cards around like Mind Control and Trade Prince Gallywix don't work properly.
