### PR TITLE
Fix minions re-appearing after death

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -221,7 +221,6 @@ class Attack(GameAction):
 		attacker.attack_target = None
 		defender.defending = False
 		attacker.num_attacks += 1
-		source.game.manager.step(source.game.next_step, Step.MAIN_END)
 
 
 class BeginTurn(GameAction):

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -112,7 +112,9 @@ class BaseGame(Entity):
 	def attack(self, source, target):
 		type = BlockType.ATTACK
 		actions = [Attack(source, target)]
-		return self.action_block(source, actions, type, target=target)
+		result = self.action_block(source, actions, type, target=target)
+		if self.state != State.COMPLETE:
+			self.manager.step(Step.MAIN_ACTION, Step.MAIN_END)
 
 	def joust(self, source, challenger, defender, actions):
 		type = BlockType.JOUST

--- a/fireplace/game.py
+++ b/fireplace/game.py
@@ -115,6 +115,7 @@ class BaseGame(Entity):
 		result = self.action_block(source, actions, type, target=target)
 		if self.state != State.COMPLETE:
 			self.manager.step(Step.MAIN_ACTION, Step.MAIN_END)
+		return result
 
 	def joust(self, source, challenger, defender, actions):
 		type = BlockType.JOUST
@@ -139,7 +140,7 @@ class BaseGame(Entity):
 
 		actions = []
 		if cards:
-			self.action_start(type, self, -1, None)
+			self.action_start(type, self, 0, None)
 			for card in cards:
 				card.zone = Zone.GRAVEYARD
 				actions.append(Death(card))


### PR DESCRIPTION
Sometimes when you trade a minion in the Hearthstone client, one or both of the dead minions reappear. Additionally, minions such as Doomsayer do not always kill everything.

This is caused by a couple of bugs: step changes being in the wrong place and the index of the DEATHS block being incorrect. These are fixed in this PR.

The new way post-combat works:

- No step change
- DEATHS block if applicable
- The action stack then unwinds
- If the game is over the step will already be changed to FINAL_WRAPUP. If it isn't, change the step back to MAIN_ACTION

This more or less precisely mirrors how the real game behaves.
