### PR TITLE
Karazhan v2: Most of the cards

### DIFF
--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -174,8 +174,9 @@ class KAR_004:
 	"Cat Trick"
 	secret = Play(ENEMY, SPELL).after(Summon(CONTROLLER, "KAR_004a"))
 
-# class KAR_013:
-# 	"Purify"
+class KAR_013:
+	"Purify"
+	play = Silence(TARGET), Draw(CONTROLLER)
 
 # class KAR_025:
 # 	"Kara Kazham!"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -181,8 +181,11 @@ class KAR_076:
 	"Firelands Portal"
 	play = Hit(TARGET, 5), Summon(CONTROLLER, RandomMinion(cost=5))
 
-# class KAR_077:
-# 	"Silvermoon Portal"
+class KAR_077:
+	"Silvermoon Portal"
+	play = Buff(TARGET, "KAR_077e"), Summon(CONTROLLER, RandomMinion(cost=2))
+
+KAR_077e = buff(+2,+2)
 
 # class KAR_091:
 # 	"Ironforge Portal"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -170,8 +170,9 @@ class KAR_710:
 ##
 # Spells
 
-# class KAR_004:
-# 	"Cat Trick"
+class KAR_004:
+	"Cat Trick"
+	secret = Play(ENEMY, SPELL).after(Summon(CONTROLLER, "KAR_004a"))
 
 # class KAR_013:
 # 	"Purify"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -119,9 +119,15 @@ KAR_095e = buff(+1,+1)
 # 	"Prince Malchezaar"
 
 
-# class KAR_097:
-# 	"Medivh, the Guardian"
+class KAR_097:
+	"Medivh, the Guardian"
+	play = Summon(CONTROLLER, "KAR_097t")
 
+class KAR_097t:
+	events = OWN_SPELL_PLAY.on(
+		Summon(CONTROLLER, RandomMinion(cost=Attr(Play.CARD, GameTag.COST))),
+		Hit(SELF, 1)
+	)
 
 class KAR_114:
 	"Barnes"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -139,9 +139,16 @@ class KAR_114e:
 # 	"Silverware Golem"
 
 
-# class KAR_702:
-# 	"Menagerie Magician"
+class KAR_702:
+	"Menagerie Magician"
+	powered_up = Find(RANDOM(FRIENDLY_MINIONS + MURLOC) | RANDOM(FRIENDLY_MINIONS + DRAGON) | RANDOM(FRIENDLY_MINIONS + BEAST))
+	play = (
+		Buff(RANDOM(FRIENDLY_MINIONS + MURLOC),"KAR_702e"),
+		Buff(RANDOM(FRIENDLY_MINIONS + DRAGON),"KAR_702e"),
+		Buff(RANDOM(FRIENDLY_MINIONS + BEAST),"KAR_702e")
+	)
 
+KAR_702e = buff(+2,+2)
 
 # class KAR_710:
 # 	"Arcanosmith"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -131,9 +131,9 @@ class KAR_114e:
 	atk = SET(1)
 	max_health = SET(1)
 
-# class KAR_204:
-# 	"Onyx Bishop"
-
+class KAR_204:
+	"Onyx Bishop"
+	play = Summon(CONTROLLER, Copy(RANDOM(FRIENDLY + KILLED + MINION)))
 
 # class KAR_205:
 # 	"Silverware Golem"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -150,9 +150,9 @@ class KAR_702:
 
 KAR_702e = buff(+2,+2)
 
-# class KAR_710:
-# 	"Arcanosmith"
-
+class KAR_710:
+	"Arcanosmith"
+	play = Summon(CONTROLLER, "KAR_710m")
 
 # class KAR_711:
 # 	"Arcane Giant"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -169,8 +169,9 @@ class KAR_114e:
 # class KAR_026:
 # 	"Protect the King!"
 
-# class KAR_073:
-# 	"Maelstrom Portal"
+class KAR_073:
+	"Maelstrom Portal"
+	play = Hit(ENEMY_MINIONS, 1), Summon(CONTROLLER, RandomMinion(cost=1))
 
 # class KAR_075:
 # 	"Moonglade Portal"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -187,8 +187,9 @@ class KAR_077:
 
 KAR_077e = buff(+2,+2)
 
-# class KAR_091:
-# 	"Ironforge Portal"
+class KAR_091:
+	"Ironforge Portal"
+	play = GainArmor(FRIENDLY_HERO, 4), Summon(CONTROLLER, RandomMinion(cost=4))
 
 ##
 # Weapons

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -173,8 +173,9 @@ class KAR_073:
 	"Maelstrom Portal"
 	play = Hit(ENEMY_MINIONS, 1), Summon(CONTROLLER, RandomMinion(cost=1))
 
-# class KAR_075:
-# 	"Moonglade Portal"
+class KAR_075:
+	"Moonglade Portal"
+	play = Heal(TARGET, 6), Summon(CONTROLLER, RandomMinion(cost=6))
 
 # class KAR_076:
 # 	"Firelands Portal"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -177,8 +177,9 @@ class KAR_075:
 	"Moonglade Portal"
 	play = Heal(TARGET, 6), Summon(CONTROLLER, RandomMinion(cost=6))
 
-# class KAR_076:
-# 	"Firelands Portal"
+class KAR_076:
+	"Firelands Portal"
+	play = Hit(TARGET, 5), Summon(CONTROLLER, RandomMinion(cost=5))
 
 # class KAR_077:
 # 	"Silvermoon Portal"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -87,9 +87,18 @@ class KAR_069:
 	"Swashburglar"
 	play = Give(CONTROLLER, RandomCollectible(card_class=ENEMY_CLASS))
 
-# class KAR_070:
-# 	"Ethereal Peddler"
+class KAR_070:
+	"Ethereal Peddler"
+	play = Buff(FRIENDLY_HAND - ROGUE, "KAR_070e")
 
+@custom_card
+class KAR_070e:
+	tags = {
+		GameTag.CARDNAME: "Ethereal Peddler Buff",
+		GameTag.CARDTYPE: CardType.ENCHANTMENT,
+		GameTag.COST: -2,
+	}
+	events = REMOVED_IN_PLAY
 
 class KAR_089:
 	"Malchezaar's Imp"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -178,8 +178,13 @@ class KAR_013:
 	"Purify"
 	play = Silence(TARGET), Draw(CONTROLLER)
 
-# class KAR_025:
-# 	"Kara Kazham!"
+class KAR_025:
+	"Kara Kazham!"
+	play = (
+		Summon(CONTROLLER, "KAR_025a"),
+		Summon(CONTROLLER, "KAR_025b"),
+		Summon(CONTROLLER, "KAR_025c")
+	)
 
 # class KAR_026:
 # 	"Protect the King!"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -164,8 +164,9 @@ class KAR_710:
 # 	"Arcane Giant"
 
 
-# class KAR_712:
-# 	"Violet Illusionist"
+class KAR_712:
+	"Violet Illusionist"
+	update = Find(CURRENT_PLAYER + CONTROLLER) & Refresh(FRIENDLY_HERO, {GameTag.IMMUNE: True})
 
 ##
 # Spells

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -197,6 +197,7 @@ class KAR_091:
 # class KAR_028:
 # 	"Fool's Bane"
 
-# class KAR_063:
-# 	"Spirit Claws"
+class KAR_063:
+	"Spirit Claws"
+	update = Find( FRIENDLY_MINIONS + SPELLPOWER ) & Refresh(SELF, {GameTag.ATK: +2})
 

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -186,8 +186,9 @@ class KAR_025:
 		Summon(CONTROLLER, "KAR_025c")
 	)
 
-# class KAR_026:
-# 	"Protect the King!"
+class KAR_026:
+	"Protect the King!"
+	play = Summon(CONTROLLER, "KAR_026t") * Count(ENEMY_MINIONS)
 
 class KAR_073:
 	"Maelstrom Portal"

--- a/fireplace/cards/karazhan/collectible.py
+++ b/fireplace/cards/karazhan/collectible.py
@@ -218,7 +218,7 @@ class KAR_091:
 # class KAR_028:
 # 	"Fool's Bane"
 
-class KAR_063:
-	"Spirit Claws"
-	update = Find( FRIENDLY_MINIONS + SPELLPOWER ) & Refresh(SELF, {GameTag.ATK: +2})
+# class KAR_063:
+# 	"Spirit Claws"
+# 	update = Find( FRIENDLY_MINIONS + SPELLPOWER ) & Refresh(SELF, {GameTag.ATK: +2})
 

--- a/fireplace/dsl/selector.py
+++ b/fireplace/dsl/selector.py
@@ -371,6 +371,7 @@ CLASS_CARD = EnumSelector(GameTag.CLASS)
 ALWAYS_WINS_BRAWLS = AttrValue(enums.ALWAYS_WINS_BRAWLS) == True
 KILLED_THIS_TURN = AttrValue(enums.KILLED_THIS_TURN) == True
 
+ROGUE = AttrValue(GameTag.CLASS) == 7
 
 IN_PLAY = EnumSelector(Zone.PLAY)
 IN_DECK = EnumSelector(Zone.DECK)

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -269,6 +269,34 @@ def test_zoobot():
 	assert dragon.health == 2
 	assert dragon.buffs
 
+def test_medivh():
+	game = prepare_game()
+	game.player1.give("KAR_097").play()
+	assert game.player1.weapon
+	assert game.player1.weapon.durability == 3
+	
+	game.player1.give(MOONFIRE).play(target=game.player1.hero)
+	assert len(game.player1.field) == 2
+	assert game.player1.field[-1].cost == 0
+	assert game.player1.weapon.durability == 2
+
+	game.end_turn()
+	game.end_turn()
+
+	game.player1.give(UNSTABLE_PORTAL).play()
+	assert len(game.player1.field) == 3
+	assert game.player1.field[-1].cost == 2
+	assert game.player1.weapon.durability == 1
+
+	game.player1.give("EX1_295").play()
+	assert len(game.player1.field) == 4
+	assert game.player1.field[-1].cost == 3
+	assert not game.player1.weapon
+
+	game.player1.give(INNERVATE).play()
+	assert len(game.player1.field) == 4
+	
+
 def test_barnes():
 	game = prepare_empty_game()
 	kobold = game.player1.give(KOBOLD_GEOMANCER)

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -291,6 +291,9 @@ def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()
 	game.end_turn()
+	assert len(game.player1.field) == 1
+	assert len(game.player2.field) == 0
+
 	game.player2.give("KAR_073").play()
 	assert len(game.player1.field) == 0
 	assert len(game.player2.field) == 1
@@ -299,12 +302,18 @@ def test_maelstrom_portal():
 def test_moonglade_portal():
 	game = prepare_game()
 	game.player1.hero.set_current_health(20)
+	assert len(game.player1.field) == 0
+	assert game.player1.hero.health == 20
+
 	game.player1.give("KAR_075").play(target=game.player1.hero)
 	assert len(game.player1.field) == 1
 	assert game.player1.hero.health == 26
 
 def test_firelands_portal():
 	game = prepare_game()
+	assert len(game.player1.field) == 0
+	assert game.player2.hero.health == 30
+
 	game.player1.give("KAR_076").play(target=game.player2.hero)
 	assert len(game.player1.field) == 1
 	assert game.player1.field[0].cost == 5
@@ -315,6 +324,10 @@ def test_silvermoon_portal():
 	portal = game.player1.give("KAR_077")
 	assert not portal.is_playable()
 	whelp = game.player1.give(WHELP).play()
+	assert len(game.player1.field) == 1
+	assert whelp.atk == 1
+	assert whelp.health == 1
+
 	portal.play(target=whelp)
 	assert whelp.atk == 3
 	assert whelp.health == 3
@@ -322,5 +335,14 @@ def test_silvermoon_portal():
 	assert len(game.player1.field) == 2
 	assert game.player1.field[-1].cost == 2
 
+def test_ironforge_portal():
+	game = prepare_game()
+	assert game.player1.hero.armor == 0
+	assert len(game.player1.field) == 0
+
+	portal = game.player1.give("KAR_091").play()
+	assert game.player1.hero.armor == 4
+	assert len(game.player1.field) == 1
+	assert game.player1.field[0].cost == 4
 
 

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -288,24 +288,39 @@ def test_barnes():
 
 
 def test_maelstrom_portal():
-	g=prepare_game()
-	g.player1.give(WISP).play()
-	g.end_turn()
-	g.player2.give("KAR_073").play()
-	assert len(g.player1.field) == 0
-	assert len(g.player2.field) == 1
-	assert g.player2.field[0].cost == 1
+	game = prepare_game()
+	game.player1.give(WISP).play()
+	game.end_turn()
+	game.player2.give("KAR_073").play()
+	assert len(game.player1.field) == 0
+	assert len(game.player2.field) == 1
+	assert game.player2.field[0].cost == 1
 
 def test_moonglade_portal():
-	g=prepare_game()
-	g.player1.hero.set_current_health(20)
-	g.player1.give("KAR_075").play(target=g.player1.hero)
-	assert len(g.player1.field) == 1
-	assert g.player1.hero.health == 26
+	game = prepare_game()
+	game.player1.hero.set_current_health(20)
+	game.player1.give("KAR_075").play(target=game.player1.hero)
+	assert len(game.player1.field) == 1
+	assert game.player1.hero.health == 26
 
 def test_firelands_portal():
-	g=prepare_game()
-	g.player1.give("KAR_076").play(target=g.player2.hero)
-	assert len(g.player1.field) == 1
-	assert g.player1.field[0].cost == 5
-	assert g.player2.hero.health == 25
+	game = prepare_game()
+	game.player1.give("KAR_076").play(target=game.player2.hero)
+	assert len(game.player1.field) == 1
+	assert game.player1.field[0].cost == 5
+	assert game.player2.hero.health == 25
+
+def test_silvermoon_portal():
+	game = prepare_game()
+	portal = game.player1.give("KAR_077")
+	assert not portal.is_playable()
+	whelp = game.player1.give(WHELP).play()
+	portal.play(target=whelp)
+	assert whelp.atk == 3
+	assert whelp.health == 3
+	assert whelp.buff
+	assert len(game.player1.field) == 2
+	assert game.player1.field[-1].cost == 2
+
+
+

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -302,3 +302,10 @@ def test_moonglade_portal():
 	g.player1.give("KAR_075").play(target=g.player1.hero)
 	assert len(g.player1.field) == 1
 	assert g.player1.hero.health == 26
+
+def test_firelands_portal():
+	g=prepare_game()
+	g.player1.give("KAR_076").play(target=g.player2.hero)
+	assert len(g.player1.field) == 1
+	assert g.player1.field[0].cost == 5
+	assert g.player2.hero.health == 25

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -305,6 +305,13 @@ def test_menagerie_magician():
 	assert dragon.health == 3
 	assert dragon.buffs
 
+def test_arcanosmith():
+	game = prepare_game()
+	game.player1.give("KAR_710").play()
+	assert len(game.player1.field) == 2
+	assert game.player1.field[-1].id == "KAR_710m"
+	assert game.player1.field[-1].taunt
+
 def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -295,3 +295,10 @@ def test_maelstrom_portal():
 	assert len(g.player1.field) == 0
 	assert len(g.player2.field) == 1
 	assert g.player2.field[0].cost == 1
+
+def test_moonglade_portal():
+	g=prepare_game()
+	g.player1.hero.set_current_health(20)
+	g.player1.give("KAR_075").play(target=g.player1.hero)
+	assert len(g.player1.field) == 1
+	assert g.player1.hero.health == 26

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -352,6 +352,22 @@ def test_arcanosmith():
 	assert game.player1.field[-1].id == "KAR_710m"
 	assert game.player1.field[-1].taunt
 
+def test_violet_illusionist():
+	game = prepare_game()
+	game.player1.give("KAR_712").play()
+	assert game.player1.hero.immune
+	game.player1.give("CS2_064").play() #Dread Infernal
+	assert game.player1.hero.health == 30
+	assert game.player2.hero.health == 29
+
+	game.end_turn()
+
+	assert not game.player1.hero.immune
+	game.player2.give("CS2_064").play() #Dread Infernal
+	assert game.player1.hero.health == 29
+	assert game.player2.hero.health == 28
+
+
 def test_cat_trick():
 	game = prepare_game()
 	cattrick = game.player1.give("KAR_004").play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -287,3 +287,11 @@ def test_barnes():
 	assert summon.health == 1
 
 
+def test_maelstrom_portal():
+	g=prepare_game()
+	g.player1.give(WISP).play()
+	g.end_turn()
+	g.player2.give("KAR_073").play()
+	assert len(g.player1.field) == 0
+	assert len(g.player2.field) == 1
+	assert g.player2.field[0].cost == 1

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -352,6 +352,16 @@ def test_arcanosmith():
 	assert game.player1.field[-1].id == "KAR_710m"
 	assert game.player1.field[-1].taunt
 
+def test_cat_trick():
+	game = prepare_game()
+	cattrick = game.player1.give("KAR_004").play()
+	assert cattrick in game.player1.secrets
+	game.end_turn()
+
+	game.player2.give("CS2_032").play()
+	assert len(game.player1.field) == 1
+	assert game.player1.field[-1].id == "KAR_004a"
+
 def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -197,6 +197,19 @@ def test_swashburglar():
 	assert game.player1.hand[0].card_class == game.player2.hero.card_class
 	assert game.player1.hand[0].type != CardType.HERO
 
+def test_ethereal_peddler():
+	game = prepare_empty_game()
+	game.player1.discard_hand()
+	mc = game.player1.give(MIND_CONTROL)
+	evis = game.player1.give("EX1_124") #Eviscerate
+	assert mc.cost == 10
+	assert evis.cost == 2
+	game.player1.give("KAR_070").play()
+	
+	assert mc.cost == 8
+	assert evis.cost == 2
+
+
 def test_malchezaars_imp():
 	game = prepare_game()
 	imp = game.player1.give("KAR_089")

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -286,6 +286,24 @@ def test_barnes():
 	assert summon.atk == 1
 	assert summon.health == 1
 
+def test_menagerie_magician():
+	game = prepare_game()
+	zoobot = game.player1.give("KAR_702")
+	murloc = game.player1.give(MURLOC).play()
+	beast = game.player1.give(CHICKEN).play()
+	dragon = game.player1.give(WHELP).play()
+	assert zoobot.powered_up
+	zoobot.play()
+
+	assert murloc.atk == 3
+	assert murloc.health == 3
+	assert murloc.buffs
+	assert beast.atk == 3
+	assert beast.health == 3
+	assert beast.buffs
+	assert dragon.atk == 3
+	assert dragon.health == 3
+	assert dragon.buffs
 
 def test_maelstrom_portal():
 	game = prepare_game()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -463,12 +463,12 @@ def test_ironforge_portal():
 	assert len(game.player1.field) == 1
 	assert game.player1.field[0].cost == 4
 
-def test_spirit_claws():
-	game = prepare_game()
-	game.player1.give("KAR_063").play()
-	assert game.player1.hero.atk == 1
-	kobold = game.player1.give(KOBOLD_GEOMANCER).play()
-	assert game.player1.hero.atk == 3
+# def test_spirit_claws():
+# 	game = prepare_game()
+# 	game.player1.give("KAR_063").play()
+# 	assert game.player1.hero.atk == 1
+# 	kobold = game.player1.give(KOBOLD_GEOMANCER).play()
+# 	assert game.player1.hero.atk == 3
 
-	game.player1.give(SILENCE).play(target=kobold)
-	assert game.player1.hero.atk == 1
+# 	game.player1.give(SILENCE).play(target=kobold)
+# 	assert game.player1.hero.atk == 1

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -380,6 +380,18 @@ def test_purify():
 	game.player1.give(MOONFIRE).play(target=acolyte2)
 	assert len(game.player1.hand) == handsize
 	
+def test_kara_kazham():
+	game = prepare_game()
+	game.player1.give("KAR_025").play()
+	assert len(game.player1.field) == 3
+	game.player1.give("KAR_025").play()
+	assert len(game.player1.field) == 6
+	game.end_turn()
+	game.end_turn()
+	game.player1.give("KAR_025").play()
+	assert len(game.player1.field) == 7
+	assert game.player1.field[-1].id == "KAR_025a"
+
 def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -392,6 +392,19 @@ def test_kara_kazham():
 	assert len(game.player1.field) == 7
 	assert game.player1.field[-1].id == "KAR_025a"
 
+def test_protect_the_king():
+	game=prepare_game()
+	ptk = game.player1.give("KAR_026")
+	assert not ptk.is_playable()
+	game.end_turn()
+
+	game.player2.give(WISP).play()
+	game.player2.give(WHELP).play()
+	game.end_turn()
+	assert ptk.is_playable()
+	ptk.play()
+	assert len(game.player1.field) == 2
+
 def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -362,6 +362,24 @@ def test_cat_trick():
 	assert len(game.player1.field) == 1
 	assert game.player1.field[-1].id == "KAR_004a"
 
+def test_purify():
+	game = prepare_game()
+	game.player1.discard_hand()
+	purify = game.player1.give("KAR_013")
+	assert not purify.is_playable()
+	game.end_turn()
+
+	acolyte1 = game.player2.give("EX1_007").play()
+	game.end_turn()
+
+	assert not purify.is_playable()
+	acolyte2 = game.player1.give("EX1_007").play()
+	assert purify.is_playable()
+	purify.play(target=acolyte2)
+	handsize = len(game.player1.hand)
+	game.player1.give(MOONFIRE).play(target=acolyte2)
+	assert len(game.player1.hand) == handsize
+	
 def test_maelstrom_portal():
 	game = prepare_game()
 	game.player1.give(WISP).play()

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -286,6 +286,18 @@ def test_barnes():
 	assert summon.atk == 1
 	assert summon.health == 1
 
+def test_onyx_bishop():
+	game = prepare_game()
+	wisp = game.player1.give(WISP).play()
+	game.player1.give("CS2_009").play(target=wisp)
+	assert wisp.atk == 3
+	game.player1.give(SOULFIRE).play(target=wisp)
+	assert len(game.player1.field) == 0
+	game.player1.give("KAR_204").play()
+
+	assert len(game.player1.field) == 2
+	assert game.player1.field[-1].atk == 1
+
 def test_menagerie_magician():
 	game = prepare_game()
 	zoobot = game.player1.give("KAR_702")

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -345,4 +345,12 @@ def test_ironforge_portal():
 	assert len(game.player1.field) == 1
 	assert game.player1.field[0].cost == 4
 
+def test_spirit_claws():
+	game = prepare_game()
+	game.player1.give("KAR_063").play()
+	assert game.player1.hero.atk == 1
+	kobold = game.player1.give(KOBOLD_GEOMANCER).play()
+	assert game.player1.hero.atk == 3
 
+	game.player1.give(SILENCE).play(target=kobold)
+	assert game.player1.hero.atk == 1


### PR DESCRIPTION
Most of the cards are now implemented except for the following (and what I did not know how to):

- Moat Lurker (How to cache a minion ID for the deathrattle)
- Ivory Knight (How to select the chosen card from Discover)
- Prince Malchezaar (How to setup start game trigger)
- Silverware Golem (How to setup event listener in hand but triggers after discard)
- Arcane Giant (Requires a SPELLS_CASTED_THIS_GAME count)
- Fool's Bane (Couldn't get the CANNOT_ATTACK_HEROES to work)
- Spirit Claws (Implemented but commented out due to spellpower not silenceable)