### PR TITLE
Added Poisonous as a keyword

### DIFF
--- a/fireplace/cards/blackrock/collectible.py
+++ b/fireplace/cards/blackrock/collectible.py
@@ -67,10 +67,9 @@ class BRM_018:
 	"Dragon Consort"
 	play = Buff(CONTROLLER, "BRM_018e")
 
-BRM_018e = buff(cost=-3)
-
 
 class BRM_018e:
+	update = Refresh(FRIENDLY_HAND + DRAGON, {GameTag.COST: -2})
 	events = Play(CONTROLLER, DRAGON).on(Destroy(SELF))
 
 

--- a/tests/implemented.py
+++ b/tests/implemented.py
@@ -17,7 +17,7 @@ PREFIXES = {
 }
 
 SOLVED_KEYWORDS = [
-	"Windfury", "Charge", "Divine Shield", "Taunt", "Stealth",
+	"Windfury", "Charge", "Divine Shield", "Taunt", "Stealth", "Poisonous",
 	r"Can't be targeted by spells or Hero Powers\.",
 	r"Can't attack\.",
 	"Destroy any minion damaged by this minion.",

--- a/tests/test_blackrock.py
+++ b/tests/test_blackrock.py
@@ -69,6 +69,39 @@ def test_chromaggus_naturalize():
 	assert game.player1.hand[2] == game.player1.hand[3]
 
 
+def test_dragon_consort():
+	game = prepare_game()
+	game.player1.discard_hand()
+	consort1 = game.player1.give("BRM_018")
+	consort2 = game.player1.give("BRM_018")
+	ysera = game.player1.give("EX1_572")
+	scaled1 = game.player1.give("OG_271")
+	scaled2 = game.player2.give("OG_271")
+	corruptor1 = game.player1.give("BRM_034")
+	corruptor2 = game.player2.give("BRM_034")
+	consort1.play()
+	assert consort2.cost == 5 - 2
+	assert ysera.cost == 9 - 2
+	assert scaled1.cost == 6 - 2
+	assert scaled2.cost == 6
+	assert corruptor1.cost == corruptor2.cost == 5
+	consort2.play()
+	assert ysera.cost == 9 - 2
+	assert scaled1.cost == 6 - 2
+	assert scaled2.cost == 6
+	assert corruptor1.cost == corruptor2.cost == 5
+	game.end_turn()
+	game.end_turn()
+	
+	assert ysera.cost == 9 - 2
+	assert scaled1.cost == 6 - 2
+	assert scaled2.cost == 6
+	assert corruptor1.cost == corruptor2.cost == 5
+	ysera.play()
+	assert scaled1.cost == scaled2.cost == 6
+	assert corruptor1.cost == corruptor2.cost == 5
+
+
 def test_dragon_egg():
 	game = prepare_game(CardClass.PRIEST, CardClass.PRIEST)
 	egg = game.player1.give("BRM_022")

--- a/tests/test_karazhan.py
+++ b/tests/test_karazhan.py
@@ -329,7 +329,7 @@ def test_barnes():
 	assert summon.health == 1
 
 def test_onyx_bishop():
-	game = prepare_game()
+	game = prepare_empty_game()
 	wisp = game.player1.give(WISP).play()
 	game.player1.give("CS2_009").play(target=wisp)
 	assert wisp.atk == 3


### PR DESCRIPTION
Noticed that implemented.py would show cards with "Poisonous" (emperor cobra, giant wasp, etc.) as unimplemented, even though they function properly. This change just labels them implemented.