### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/fireplace/actions.py
+++ b/fireplace/actions.py
@@ -740,7 +740,7 @@ class Damage(TargetedAction):
 			if hasattr(source, "lifesteal") and source.lifesteal and source.type != CardType.WEAPON:
 				source.heal(source.controller.hero, amount)
 			self.broadcast(source, EventListener.ON, target, amount, source)
-			# poisonous can not destory hero
+			# poisonous can not destroy hero
 			if hasattr(source, "poisonous") and source.poisonous and (
 				target.type != CardType.HERO and source.type != CardType.WEAPON):
 				target.destroy()

--- a/fireplace/dsl/evaluator.py
+++ b/fireplace/dsl/evaluator.py
@@ -85,7 +85,7 @@ class Attacking(Evaluator):
 class ChooseBoth(Evaluator):
 	"""
 	Evaluates to True if the selector `choose_both` is true
-	Selector must evalutae to only one player.
+	Selector must evaluate to only one player.
 	"""
 	def __init__(self, selector):
 		super().__init__()

--- a/tests/test_wog.py
+++ b/tests/test_wog.py
@@ -414,7 +414,7 @@ def test_scaled_nightmare():
 
 
 def test_scaled_nightmare_buff_ordering():
-	# To show that fireplace doesn't have blizzard's truly bizzare bugs.
+	# To show that fireplace doesn't have blizzard's truly bizarre bugs.
 	# cf: HearthSim/hs-bugs#462
 	# "Scaled Nightmare stops doubling Attack if its Attack value is Direct Set"
 	game = prepare_game()


### PR DESCRIPTION
There are small typos in:
- fireplace/actions.py
- fireplace/dsl/evaluator.py
- tests/test_wog.py

Fixes:
- Should read `evaluate` rather than `evalutae`.
- Should read `destroy` rather than `destory`.
- Should read `bizarre` rather than `bizzare`.

Closes #489