### PR TITLE
Fix bug

### DIFF
--- a/fireplace/cards/classic/neutral_epic.py
+++ b/fireplace/cards/classic/neutral_epic.py
@@ -20,7 +20,7 @@ class EX1_507:
 	update = Refresh(FRIENDLY_MINIONS + MURLOC - SELF, buff="EX1_507e")
 
 
-EX1_507e = buff(atk=2)
+EX1_507e = buff(+2, +1)
 
 
 class EX1_564:

--- a/fireplace/cards/tgt/neutral_legendary.py
+++ b/fireplace/cards/tgt/neutral_legendary.py
@@ -66,7 +66,7 @@ class AT_132:
 		"CS2_034_H2": "CS2_034_H2_AT_132",  # Khadgar
 		# Paladin
 		"CS2_101": "AT_132_PALADIN",  # Uther Lightbringer
-		"CS2_101_H": "CS2_101_H1_AT_132",  # Lady Liadrin
+		"CS2_101_H1": "CS2_101_H1_AT_132",  # Lady Liadrin
 		# Priest
 		"CS1h_001": "AT_132_PRIEST",  # Anduin Wrynn
 		"CS1h_001_H1": "CS1h_001_H1_AT_132",  # Tyrande Whisperwind


### PR DESCRIPTION
* `Murloc Warleader (EX1_507)` buff in 8.4.0 is `+2/+1`
* Upgrade hero power map of `Lady Liadrin` is `CS2_101_H1`